### PR TITLE
feat: add specialized tool visualization cards

### DIFF
--- a/frontend/src/components/tools/BashCard.tsx
+++ b/frontend/src/components/tools/BashCard.tsx
@@ -1,0 +1,64 @@
+import { Show } from "solid-js";
+import ToolCardBase from "./ToolCardBase";
+
+interface BashCardProps {
+  command: string;
+  output?: string;
+  exitCode?: number;
+  isError?: boolean;
+  executionMs?: number;
+}
+
+export default function BashCard(props: BashCardProps) {
+  return (
+    <ToolCardBase
+      toolName="Bash"
+      isError={props.isError}
+      executionMs={props.executionMs}
+    >
+      <div
+        style={{
+          background: "var(--ctp-crust)",
+          "border-radius": "6px",
+          padding: "8px 10px",
+          "font-family": "var(--font-mono)",
+          "font-size": "11px",
+          "max-height": "400px",
+          overflow: "auto",
+        }}
+      >
+        <div
+          style={{
+            color: "var(--ctp-green)",
+            "margin-bottom": "4px",
+          }}
+        >
+          $ {props.command}
+        </div>
+        <Show when={props.output}>
+          <pre
+            style={{
+              margin: "0",
+              color: "var(--ctp-subtext0)",
+              "white-space": "pre-wrap",
+              "word-break": "break-word",
+            }}
+          >
+            {props.output}
+          </pre>
+        </Show>
+      </div>
+      <Show when={props.exitCode != null && props.exitCode !== 0}>
+        <div
+          style={{
+            "margin-top": "4px",
+            "font-size": "10px",
+            color: "var(--ctp-red)",
+          }}
+        >
+          exit code: {props.exitCode}
+        </div>
+      </Show>
+    </ToolCardBase>
+  );
+}

--- a/frontend/src/components/tools/EditCard.tsx
+++ b/frontend/src/components/tools/EditCard.tsx
@@ -1,0 +1,81 @@
+import { Show, For } from "solid-js";
+import ToolCardBase from "./ToolCardBase";
+
+interface EditCardProps {
+  filePath: string;
+  oldString?: string;
+  newString?: string;
+  isError?: boolean;
+  result?: string;
+}
+
+export default function EditCard(props: EditCardProps) {
+  const oldLines = () => (props.oldString ?? "").split("\n");
+  const newLines = () => (props.newString ?? "").split("\n");
+
+  return (
+    <ToolCardBase toolName="Edit" isError={props.isError}>
+      <div
+        style={{
+          "font-family": "var(--font-mono)",
+          "font-size": "11px",
+          color: "var(--ctp-blue)",
+          "margin-bottom": "8px",
+        }}
+      >
+        {props.filePath}
+      </div>
+      <Show when={props.oldString || props.newString}>
+        <div
+          style={{
+            "font-family": "var(--font-mono)",
+            "font-size": "11px",
+            "line-height": "1.6",
+            "max-height": "300px",
+            overflow: "auto",
+          }}
+        >
+          <For each={oldLines()}>
+            {(line) => (
+              <div
+                style={{
+                  background: "rgba(243, 139, 168, 0.1)",
+                  color: "var(--ctp-red)",
+                  padding: "0 4px",
+                }}
+              >
+                - {line}
+              </div>
+            )}
+          </For>
+          <For each={newLines()}>
+            {(line) => (
+              <div
+                style={{
+                  background: "rgba(166, 227, 161, 0.1)",
+                  color: "var(--ctp-green)",
+                  padding: "0 4px",
+                }}
+              >
+                + {line}
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+      <Show when={props.result}>
+        <pre
+          style={{
+            margin: "4px 0 0",
+            "font-family": "var(--font-mono)",
+            "font-size": "11px",
+            color: props.isError ? "var(--ctp-red)" : "var(--ctp-subtext0)",
+            "white-space": "pre-wrap",
+          }}
+        >
+          {props.result}
+        </pre>
+      </Show>
+    </ToolCardBase>
+  );
+}

--- a/frontend/src/components/tools/GlobCard.tsx
+++ b/frontend/src/components/tools/GlobCard.tsx
@@ -1,0 +1,90 @@
+import { Show, For } from "solid-js";
+import ToolCardBase from "./ToolCardBase";
+
+interface GlobCardProps {
+  pattern: string;
+  files?: string;
+  isError?: boolean;
+}
+
+function fileIcon(path: string): string {
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  const icons: Record<string, string> = {
+    ts: "TS",
+    tsx: "TX",
+    js: "JS",
+    jsx: "JX",
+    rs: "RS",
+    md: "MD",
+    css: "CS",
+    json: "{}",
+    toml: "TM",
+    yaml: "YM",
+    yml: "YM",
+    html: "HT",
+  };
+  return icons[ext] ?? "..";
+}
+
+export default function GlobCard(props: GlobCardProps) {
+  const fileList = () =>
+    (props.files ?? "").split("\n").filter((f) => f.trim());
+
+  return (
+    <ToolCardBase toolName="Glob" isError={props.isError}>
+      <div
+        style={{
+          "font-family": "var(--font-mono)",
+          "font-size": "11px",
+          color: "var(--ctp-teal)",
+          "margin-bottom": "6px",
+        }}
+      >
+        {props.pattern}
+        <span style={{ color: "var(--ctp-overlay0)", "margin-left": "8px" }}>
+          {fileList().length} files
+        </span>
+      </div>
+      <Show when={fileList().length > 0}>
+        <div
+          style={{
+            "max-height": "200px",
+            overflow: "auto",
+          }}
+        >
+          <For each={fileList()}>
+            {(file) => (
+              <div
+                style={{
+                  display: "flex",
+                  "align-items": "center",
+                  gap: "6px",
+                  padding: "2px 0",
+                  "font-family": "var(--font-mono)",
+                  "font-size": "11px",
+                  color: "var(--ctp-subtext0)",
+                }}
+              >
+                <span
+                  style={{
+                    "font-size": "9px",
+                    padding: "1px 4px",
+                    "border-radius": "3px",
+                    background: "var(--ctp-surface1)",
+                    color: "var(--ctp-overlay1)",
+                    "font-weight": "600",
+                    "min-width": "20px",
+                    "text-align": "center",
+                  }}
+                >
+                  {fileIcon(file)}
+                </span>
+                {file}
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+    </ToolCardBase>
+  );
+}

--- a/frontend/src/components/tools/GrepCard.tsx
+++ b/frontend/src/components/tools/GrepCard.tsx
@@ -1,0 +1,66 @@
+import { Show, For } from "solid-js";
+import ToolCardBase from "./ToolCardBase";
+
+interface GrepCardProps {
+  pattern: string;
+  results?: string;
+  isError?: boolean;
+}
+
+export default function GrepCard(props: GrepCardProps) {
+  const lines = () => (props.results ?? "").split("\n").filter((l) => l);
+
+  return (
+    <ToolCardBase toolName="Grep" isError={props.isError}>
+      <div
+        style={{
+          "font-family": "var(--font-mono)",
+          "font-size": "11px",
+          color: "var(--ctp-yellow)",
+          "margin-bottom": "6px",
+        }}
+      >
+        /{props.pattern}/
+      </div>
+      <Show when={lines().length > 0}>
+        <div
+          style={{
+            background: "var(--ctp-crust)",
+            "border-radius": "6px",
+            padding: "6px 10px",
+            "max-height": "300px",
+            overflow: "auto",
+          }}
+        >
+          <For each={lines()}>
+            {(line) => (
+              <div
+                style={{
+                  "font-family": "var(--font-mono)",
+                  "font-size": "11px",
+                  color: "var(--ctp-subtext0)",
+                  padding: "1px 0",
+                  "white-space": "pre-wrap",
+                  "word-break": "break-word",
+                }}
+              >
+                {line}
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+      <Show when={lines().length > 0}>
+        <div
+          style={{
+            "margin-top": "4px",
+            "font-size": "10px",
+            color: "var(--ctp-overlay0)",
+          }}
+        >
+          {lines().length} matches
+        </div>
+      </Show>
+    </ToolCardBase>
+  );
+}

--- a/frontend/src/components/tools/LspCard.tsx
+++ b/frontend/src/components/tools/LspCard.tsx
@@ -1,0 +1,67 @@
+import { Show } from "solid-js";
+import ToolCardBase from "./ToolCardBase";
+
+interface LspCardProps {
+  operation: string;
+  filePath: string;
+  line?: number;
+  result?: string;
+  isError?: boolean;
+}
+
+export default function LspCard(props: LspCardProps) {
+  return (
+    <ToolCardBase toolName="LSP" isError={props.isError}>
+      <div
+        style={{
+          display: "flex",
+          gap: "8px",
+          "align-items": "center",
+          "margin-bottom": "6px",
+          "font-size": "11px",
+        }}
+      >
+        <span
+          style={{
+            padding: "1px 6px",
+            "border-radius": "4px",
+            background: "rgba(203, 166, 247, 0.15)",
+            color: "var(--ctp-mauve)",
+            "font-weight": "600",
+            "font-size": "10px",
+          }}
+        >
+          {props.operation}
+        </span>
+        <span
+          style={{
+            "font-family": "var(--font-mono)",
+            color: "var(--ctp-blue)",
+          }}
+        >
+          {props.filePath}
+          <Show when={props.line}>
+            <span style={{ color: "var(--ctp-overlay0)" }}>
+              :{props.line}
+            </span>
+          </Show>
+        </span>
+      </div>
+      <Show when={props.result}>
+        <pre
+          style={{
+            margin: "0",
+            "font-family": "var(--font-mono)",
+            "font-size": "11px",
+            color: "var(--ctp-subtext0)",
+            "white-space": "pre-wrap",
+            "max-height": "200px",
+            overflow: "auto",
+          }}
+        >
+          {props.result}
+        </pre>
+      </Show>
+    </ToolCardBase>
+  );
+}

--- a/frontend/src/components/tools/NotebookCard.tsx
+++ b/frontend/src/components/tools/NotebookCard.tsx
@@ -1,0 +1,61 @@
+import { Show } from "solid-js";
+import ToolCardBase from "./ToolCardBase";
+
+interface NotebookCardProps {
+  cellType: string;
+  content?: string;
+  isError?: boolean;
+}
+
+export default function NotebookCard(props: NotebookCardProps) {
+  return (
+    <ToolCardBase toolName="NotebookEdit" isError={props.isError}>
+      <div
+        style={{
+          display: "flex",
+          "align-items": "center",
+          gap: "6px",
+          "margin-bottom": "6px",
+          "font-size": "11px",
+        }}
+      >
+        <span
+          style={{
+            padding: "1px 6px",
+            "border-radius": "4px",
+            background:
+              props.cellType === "code"
+                ? "rgba(137, 180, 250, 0.15)"
+                : "rgba(245, 194, 231, 0.15)",
+            color:
+              props.cellType === "code"
+                ? "var(--ctp-blue)"
+                : "var(--ctp-pink)",
+            "font-weight": "600",
+            "font-size": "10px",
+          }}
+        >
+          {props.cellType}
+        </span>
+      </div>
+      <Show when={props.content}>
+        <pre
+          style={{
+            margin: "0",
+            "font-family": "var(--font-mono)",
+            "font-size": "11px",
+            color: "var(--ctp-subtext0)",
+            background: "var(--ctp-crust)",
+            "border-radius": "6px",
+            padding: "8px 10px",
+            "white-space": "pre-wrap",
+            "max-height": "200px",
+            overflow: "auto",
+          }}
+        >
+          {props.content}
+        </pre>
+      </Show>
+    </ToolCardBase>
+  );
+}

--- a/frontend/src/components/tools/PdfCard.tsx
+++ b/frontend/src/components/tools/PdfCard.tsx
@@ -1,0 +1,72 @@
+import { Show } from "solid-js";
+import ToolCardBase from "./ToolCardBase";
+
+interface PdfCardProps {
+  filePath: string;
+  pages?: string;
+  content?: string;
+  isError?: boolean;
+}
+
+export default function PdfCard(props: PdfCardProps) {
+  const preview = () => {
+    const c = props.content ?? "";
+    return c.length > 500 ? c.slice(0, 500) + "..." : c;
+  };
+
+  return (
+    <ToolCardBase toolName="Read" isError={props.isError}>
+      <div
+        style={{
+          display: "flex",
+          "align-items": "center",
+          gap: "8px",
+          "margin-bottom": "6px",
+          "font-size": "11px",
+        }}
+      >
+        <span
+          style={{
+            padding: "1px 6px",
+            "border-radius": "4px",
+            background: "rgba(250, 179, 135, 0.15)",
+            color: "var(--ctp-peach)",
+            "font-weight": "600",
+            "font-size": "10px",
+          }}
+        >
+          PDF
+        </span>
+        <span
+          style={{
+            "font-family": "var(--font-mono)",
+            color: "var(--ctp-blue)",
+          }}
+        >
+          {props.filePath}
+        </span>
+        <Show when={props.pages}>
+          <span style={{ color: "var(--ctp-overlay0)" }}>
+            pp. {props.pages}
+          </span>
+        </Show>
+      </div>
+      <Show when={preview()}>
+        <pre
+          style={{
+            margin: "0",
+            "font-size": "11px",
+            "line-height": "1.5",
+            color: "var(--ctp-subtext0)",
+            "white-space": "pre-wrap",
+            "word-break": "break-word",
+            "max-height": "200px",
+            overflow: "auto",
+          }}
+        >
+          {preview()}
+        </pre>
+      </Show>
+    </ToolCardBase>
+  );
+}

--- a/frontend/src/components/tools/PermissionCard.tsx
+++ b/frontend/src/components/tools/PermissionCard.tsx
@@ -1,0 +1,68 @@
+import ToolCardBase from "./ToolCardBase";
+
+interface PermissionCardProps {
+  tool: string;
+  description: string;
+  approved?: boolean;
+  isError?: boolean;
+}
+
+export default function PermissionCard(props: PermissionCardProps) {
+  return (
+    <ToolCardBase toolName="Permission" isError={props.isError}>
+      <div
+        style={{
+          display: "flex",
+          "align-items": "center",
+          gap: "8px",
+          "font-size": "11px",
+        }}
+      >
+        <span
+          style={{
+            padding: "1px 6px",
+            "border-radius": "4px",
+            background:
+              props.approved === true
+                ? "rgba(166, 227, 161, 0.15)"
+                : props.approved === false
+                  ? "rgba(243, 139, 168, 0.15)"
+                  : "rgba(249, 226, 175, 0.15)",
+            color:
+              props.approved === true
+                ? "var(--ctp-green)"
+                : props.approved === false
+                  ? "var(--ctp-red)"
+                  : "var(--ctp-yellow)",
+            "font-weight": "600",
+            "font-size": "10px",
+          }}
+        >
+          {props.approved === true
+            ? "Approved"
+            : props.approved === false
+              ? "Denied"
+              : "Pending"}
+        </span>
+        <span
+          style={{
+            "font-family": "var(--font-mono)",
+            color: "var(--ctp-blue)",
+          }}
+        >
+          {props.tool}
+        </span>
+      </div>
+      <div
+        style={{
+          "margin-top": "6px",
+          "font-size": "11px",
+          color: "var(--ctp-subtext0)",
+          "line-height": "1.4",
+        }}
+      >
+        {props.description}
+      </div>
+    </ToolCardBase>
+  );
+}

--- a/frontend/src/components/tools/ReadCard.tsx
+++ b/frontend/src/components/tools/ReadCard.tsx
@@ -1,0 +1,45 @@
+import { Show } from "solid-js";
+import ToolCardBase from "./ToolCardBase";
+
+interface ReadCardProps {
+  filePath: string;
+  content?: string;
+  isError?: boolean;
+}
+
+export default function ReadCard(props: ReadCardProps) {
+  return (
+    <ToolCardBase toolName="Read" isError={props.isError}>
+      <div
+        style={{
+          "font-family": "var(--font-mono)",
+          "font-size": "11px",
+          color: "var(--ctp-blue)",
+          "margin-bottom": "6px",
+        }}
+      >
+        {props.filePath}
+      </div>
+      <Show when={props.content}>
+        <pre
+          style={{
+            margin: "0",
+            "font-family": "var(--font-mono)",
+            "font-size": "11px",
+            "line-height": "1.5",
+            color: "var(--ctp-subtext0)",
+            background: "var(--ctp-crust)",
+            "border-radius": "6px",
+            padding: "8px 10px",
+            "max-height": "300px",
+            overflow: "auto",
+            "white-space": "pre-wrap",
+            "word-break": "break-word",
+          }}
+        >
+          {props.content}
+        </pre>
+      </Show>
+    </ToolCardBase>
+  );
+}

--- a/frontend/src/components/tools/ToolCardBase.tsx
+++ b/frontend/src/components/tools/ToolCardBase.tsx
@@ -1,0 +1,109 @@
+import { createSignal, Show, type JSX } from "solid-js";
+
+interface ToolCardBaseProps {
+  toolName: string;
+  isError?: boolean;
+  executionMs?: number;
+  children: JSX.Element;
+  defaultExpanded?: boolean;
+}
+
+function toolColor(name: string): string {
+  const colors: Record<string, string> = {
+    Edit: "var(--ctp-green)",
+    Bash: "var(--ctp-peach)",
+    Read: "var(--ctp-blue)",
+    Grep: "var(--ctp-yellow)",
+    Glob: "var(--ctp-teal)",
+    Write: "var(--ctp-green)",
+    WebSearch: "var(--ctp-sapphire)",
+    WebFetch: "var(--ctp-sapphire)",
+    LSP: "var(--ctp-mauve)",
+    NotebookEdit: "var(--ctp-pink)",
+    AskUserQuestion: "var(--ctp-flamingo)",
+  };
+  return colors[name] ?? "var(--ctp-peach)";
+}
+
+export default function ToolCardBase(props: ToolCardBaseProps) {
+  const [expanded, setExpanded] = createSignal(props.defaultExpanded ?? false);
+
+  return (
+    <div
+      style={{
+        margin: "4px 16px",
+        "border-radius": "8px",
+        border: `1px solid ${props.isError ? "var(--ctp-red)" : "var(--ctp-surface1)"}`,
+        background: "var(--ctp-surface0)",
+        overflow: "hidden",
+      }}
+    >
+      <button
+        onClick={() => setExpanded(!expanded())}
+        style={{
+          display: "flex",
+          "align-items": "center",
+          gap: "8px",
+          width: "100%",
+          padding: "8px 12px",
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          color: props.isError ? "var(--ctp-red)" : toolColor(props.toolName),
+          "font-size": "12px",
+          "font-weight": "600",
+          "text-align": "left",
+        }}
+      >
+        <span
+          style={{
+            transform: expanded() ? "rotate(90deg)" : "rotate(0deg)",
+            transition: "transform 150ms ease",
+            display: "inline-block",
+            "font-size": "10px",
+          }}
+        >
+          {"\u25B6"}
+        </span>
+        <span style={{ "font-family": "var(--font-mono)" }}>
+          {props.toolName}
+        </span>
+        <Show when={props.isError}>
+          <span
+            style={{
+              "font-size": "10px",
+              padding: "1px 6px",
+              "border-radius": "4px",
+              background: "rgba(243, 139, 168, 0.15)",
+              color: "var(--ctp-red)",
+            }}
+          >
+            error
+          </span>
+        </Show>
+        <Show when={props.executionMs}>
+          <span
+            style={{
+              "margin-left": "auto",
+              "font-size": "10px",
+              color: "var(--ctp-overlay0)",
+              "font-weight": "400",
+            }}
+          >
+            {props.executionMs!}ms
+          </span>
+        </Show>
+      </button>
+      <Show when={expanded()}>
+        <div
+          style={{
+            "border-top": "1px solid var(--ctp-surface1)",
+            padding: "8px 12px",
+          }}
+        >
+          {props.children}
+        </div>
+      </Show>
+    </div>
+  );
+}

--- a/frontend/src/components/tools/WebFetchCard.tsx
+++ b/frontend/src/components/tools/WebFetchCard.tsx
@@ -1,0 +1,47 @@
+import { Show } from "solid-js";
+import ToolCardBase from "./ToolCardBase";
+
+interface WebFetchCardProps {
+  url: string;
+  content?: string;
+  isError?: boolean;
+}
+
+export default function WebFetchCard(props: WebFetchCardProps) {
+  const preview = () => {
+    const c = props.content ?? "";
+    return c.length > 500 ? c.slice(0, 500) + "..." : c;
+  };
+
+  return (
+    <ToolCardBase toolName="WebFetch" isError={props.isError}>
+      <div
+        style={{
+          "font-family": "var(--font-mono)",
+          "font-size": "11px",
+          color: "var(--ctp-sapphire)",
+          "margin-bottom": "6px",
+          "word-break": "break-all",
+        }}
+      >
+        {props.url}
+      </div>
+      <Show when={preview()}>
+        <pre
+          style={{
+            margin: "0",
+            "font-size": "11px",
+            "line-height": "1.5",
+            color: "var(--ctp-subtext0)",
+            "white-space": "pre-wrap",
+            "word-break": "break-word",
+            "max-height": "200px",
+            overflow: "auto",
+          }}
+        >
+          {preview()}
+        </pre>
+      </Show>
+    </ToolCardBase>
+  );
+}

--- a/frontend/src/components/tools/WebSearchCard.tsx
+++ b/frontend/src/components/tools/WebSearchCard.tsx
@@ -1,0 +1,40 @@
+import { Show } from "solid-js";
+import ToolCardBase from "./ToolCardBase";
+
+interface WebSearchCardProps {
+  query: string;
+  results?: string;
+  isError?: boolean;
+}
+
+export default function WebSearchCard(props: WebSearchCardProps) {
+  return (
+    <ToolCardBase toolName="WebSearch" isError={props.isError}>
+      <div
+        style={{
+          "font-size": "12px",
+          color: "var(--ctp-sapphire)",
+          "margin-bottom": "6px",
+        }}
+      >
+        Search: {props.query}
+      </div>
+      <Show when={props.results}>
+        <pre
+          style={{
+            margin: "0",
+            "font-size": "11px",
+            "line-height": "1.5",
+            color: "var(--ctp-subtext0)",
+            "white-space": "pre-wrap",
+            "word-break": "break-word",
+            "max-height": "300px",
+            overflow: "auto",
+          }}
+        >
+          {props.results}
+        </pre>
+      </Show>
+    </ToolCardBase>
+  );
+}

--- a/frontend/src/components/tools/index.ts
+++ b/frontend/src/components/tools/index.ts
@@ -1,0 +1,12 @@
+export { default as ToolCardBase } from "./ToolCardBase";
+export { default as EditCard } from "./EditCard";
+export { default as BashCard } from "./BashCard";
+export { default as ReadCard } from "./ReadCard";
+export { default as GrepCard } from "./GrepCard";
+export { default as GlobCard } from "./GlobCard";
+export { default as WebSearchCard } from "./WebSearchCard";
+export { default as WebFetchCard } from "./WebFetchCard";
+export { default as LspCard } from "./LspCard";
+export { default as NotebookCard } from "./NotebookCard";
+export { default as PdfCard } from "./PdfCard";
+export { default as PermissionCard } from "./PermissionCard";


### PR DESCRIPTION
## Summary
- Add 11 specialized tool card components (Edit, Bash, Read, Grep, Glob, WebSearch, WebFetch, LSP, NotebookEdit, PDF, Permission) with rich visual rendering
- Add shared ToolCardBase with collapsible layout, tool-specific accent colors, error states, and execution time display
- Update ChatPanel ToolCard to dispatch to specialized cards by tool name with generic fallback

Closes #19

## Test plan
- [x] `npm run build` passes (70.6KB JS, 14.15KB CSS)
- [ ] Visual inspection of each tool card type with sample data
- [ ] Verify collapsible behavior on all card types
- [ ] Verify error state styling (red border, error badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)