### PR TITLE
ci: add AC evidence gate workflow

### DIFF
--- a/.github/workflows/ac-evidence-gate.yml
+++ b/.github/workflows/ac-evidence-gate.yml
@@ -1,0 +1,239 @@
+name: AC Evidence Gate
+
+# Prevents closing issues without real test evidence.
+# Catches the anti-pattern of marking ACs as PASS based on
+# code review alone (line numbers, "structure exists", etc.)
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  evidence-gate:
+    name: AC Evidence Gate
+    runs-on: ubuntu-latest
+    # Only enforce on scope:full issues (work packages)
+    if: contains(join(github.event.issue.labels.*.name, ','), 'scope:full')
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const body = (issue.body || "");
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = issue.number;
+
+            const failures = [];
+            const warnings = [];
+
+            // ─────────────────────────────────────────────────────
+            // 1. AC Audit section must exist
+            // ─────────────────────────────────────────────────────
+            const hasAcAudit = /## AC Audit/i.test(body);
+            if (!hasAcAudit) {
+              failures.push(
+                "Missing `## AC Audit` section. Every scope:full issue must have " +
+                "an AC Audit table with PASS/FAIL/N/A verdicts and evidence before closing."
+              );
+            }
+
+            // ─────────────────────────────────────────────────────
+            // 2. Extract all AC-IDs from the issue body
+            // ─────────────────────────────────────────────────────
+            const allAcIds = [...new Set(
+              (body.match(/AC-\d+-\d+/g) || [])
+            )];
+
+            if (allAcIds.length === 0) {
+              // Fallback: try AC-N format (without WP prefix)
+              const simpleAcIds = [...new Set(
+                (body.match(/\bAC-\d+\b/g) || [])
+              )];
+              if (simpleAcIds.length === 0) {
+                failures.push("No AC-IDs found in issue body.");
+              }
+            }
+
+            // ─────────────────────────────────────────────────────
+            // 3. Check AC Audit section for real evidence
+            // ─────────────────────────────────────────────────────
+            if (hasAcAudit) {
+              // Extract the AC Audit section
+              const auditSectionMatch = body.match(
+                /## AC Audit[\s\S]*?(?=\n## |\n---|\Z|$)/
+              );
+              const auditSection = auditSectionMatch
+                ? auditSectionMatch[0]
+                : "";
+
+              // Find all PASS verdicts in the audit section
+              const passLines = auditSection.split("\n").filter(line =>
+                /\bPASS\b/i.test(line)
+              );
+
+              if (passLines.length === 0 && allAcIds.length > 0) {
+                failures.push(
+                  "AC Audit section exists but contains no PASS/FAIL/N/A verdicts."
+                );
+              }
+
+              // ─────────────────────────────────────────────────────
+              // 4. CRITICAL: Check that PASS verdicts have code blocks
+              //    (actual command output), not just line references
+              // ─────────────────────────────────────────────────────
+              const hasCodeBlocks = /```[\s\S]*?```/g.test(auditSection);
+
+              // Detect fake evidence patterns:
+              // - Line number references like "file.rs:42", "Component.tsx:15"
+              // - "Code review", "structure exists", "pattern implemented"
+              const FAKE_EVIDENCE_PATTERNS = [
+                /\w+\.(rs|ts|tsx|js|css|html):\d+/,  // file.ext:linenum
+                /\bcode review\b/i,
+                /\bstructure exists\b/i,
+                /\bpattern implemented\b/i,
+                /\bsieht korrekt aus\b/i,
+                /\blooks correct\b/i,
+                /\bcode gelesen\b/i,
+                /\bread the code\b/i,
+                /\bimplemented as expected\b/i,
+                /\bwie erwartet implementiert\b/i,
+              ];
+
+              // Check each PASS line for fake evidence
+              for (const line of passLines) {
+                const hasFakeEvidence = FAKE_EVIDENCE_PATTERNS.some(p =>
+                  p.test(line)
+                );
+                if (hasFakeEvidence && !hasCodeBlocks) {
+                  failures.push(
+                    "PASS verdict uses code-review language or line-number " +
+                    "references instead of real command output. " +
+                    "Evidence must be: command executed + output received, " +
+                    "screenshot taken, or measurement performed. " +
+                    "Line: `" + line.trim().substring(0, 120) + "`"
+                  );
+                }
+              }
+
+              // If there are PASS verdicts but zero code blocks in entire
+              // audit section, that's suspicious
+              if (passLines.length > 0 && !hasCodeBlocks) {
+                failures.push(
+                  "AC Audit has " + passLines.length + " PASS verdict(s) but " +
+                  "no code blocks (``` ``` ) with command output anywhere in " +
+                  "the section. Every PASS needs evidence: the exact command " +
+                  "that was run and its output."
+                );
+              }
+
+              // ─────────────────────────────────────────────────────
+              // 5. Check that all AC-IDs have a verdict
+              // ─────────────────────────────────────────────────────
+              const acIdsToCheck = allAcIds.length > 0 ? allAcIds :
+                [...new Set((body.match(/\bAC-\d+\b/g) || []))];
+
+              const missingVerdicts = acIdsToCheck.filter(ac => {
+                // Check if this AC-ID appears in audit section with a verdict
+                const pattern = new RegExp(
+                  ac.replace("-", "[-\\s]") + "[^\\n]*\\b(PASS|FAIL|N\\/A|UNTESTED)\\b",
+                  "i"
+                );
+                return !pattern.test(auditSection);
+              });
+
+              if (missingVerdicts.length > 0) {
+                warnings.push(
+                  "AC-IDs without verdict in AC Audit section: " +
+                  missingVerdicts.join(", ") +
+                  ". Every AC must have PASS, FAIL, N/A, or UNTESTED."
+                );
+              }
+
+              // ─────────────────────────────────────────────────────
+              // 6. UNTESTED is never acceptable for closing
+              // ─────────────────────────────────────────────────────
+              const untestedLines = auditSection.split("\n").filter(line =>
+                /\bUNTESTED\b/i.test(line)
+              );
+              if (untestedLines.length > 0) {
+                failures.push(
+                  "Found " + untestedLines.length + " UNTESTED verdict(s). " +
+                  "Issues cannot be closed with UNTESTED ACs. " +
+                  "Run the actual tests and update to PASS, FAIL, or N/A."
+                );
+              }
+            }
+
+            // ── Apply result ─────────────────────────────────────
+            if (failures.length > 0) {
+              // Reopen the issue
+              await github.rest.issues.update({
+                owner, repo, issue_number,
+                state: "open"
+              });
+
+              // Ensure label exists
+              try {
+                await github.rest.issues.getLabel({
+                  owner, repo, name: "quality:needs-evidence"
+                });
+              } catch {
+                await github.rest.issues.createLabel({
+                  owner, repo,
+                  name: "quality:needs-evidence",
+                  color: "d93f0b",
+                  description: "AC evidence missing or insufficient"
+                });
+              }
+
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number,
+                labels: ["quality:needs-evidence"]
+              });
+
+              let commentBody =
+                "**AC Evidence Gate: FAILED — Issue reopened**\n\n" +
+                "This issue was closed without sufficient test evidence. " +
+                "Code review and line numbers are NOT evidence. " +
+                "Evidence means: command executed + output received.\n\n" +
+                "### Errors\n" +
+                failures.map(f => `- ${f}`).join("\n");
+
+              if (warnings.length > 0) {
+                commentBody +=
+                  "\n\n### Warnings\n" +
+                  warnings.map(w => `- ${w}`).join("\n");
+              }
+
+              commentBody +=
+                "\n\n### What counts as evidence?\n" +
+                "- Command output in code blocks (e.g., `cargo test` output)\n" +
+                "- Screenshots of the running application\n" +
+                "- Performance measurements with actual numbers\n" +
+                "- Test suite results with pass/fail counts\n\n" +
+                "### What does NOT count as evidence?\n" +
+                "- File paths with line numbers (e.g., `Component.tsx:42`)\n" +
+                "- \"Code looks correct\" / \"Structure exists\"\n" +
+                "- Code review without execution\n" +
+                "- \"Pattern implemented as expected\"";
+
+              await github.rest.issues.createComment({
+                owner, repo, issue_number,
+                body: commentBody
+              });
+
+              core.setFailed(
+                "AC Evidence Gate failed: " + failures.length + " error(s). Issue reopened."
+              );
+            } else if (warnings.length > 0) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number,
+                body:
+                  "**AC Evidence Gate: PASSED with warnings**\n\n" +
+                  warnings.map(w => `- ${w}`).join("\n")
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ generated/
 .audit/
 IMPL-PLAN.md
 
+# ── Test Artifacts ────────────────────────────────────────────
+.playwright-cli/
+
 # ── Misc ───────────────────────────────────────────────────────
 __pycache__/
 *.pyc


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow (`ac-evidence-gate.yml`) that prevents closing issues without real test evidence in the AC audit section
- Add `.playwright-cli/` to `.gitignore` to keep test screenshots/snapshots out of the repo

## Test plan
- [ ] CI Gate passes (no Rust/frontend changes, docs-only PR)
- [ ] Conventional Commits check passes
- [ ] CodeQL passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)