### PR TITLE
fix: remove invalid \Z regex in AC Evidence Gate workflow

### DIFF
--- a/.github/workflows/ac-evidence-gate.yml
+++ b/.github/workflows/ac-evidence-gate.yml
@@ -64,7 +64,7 @@ jobs:
             if (hasAcAudit) {
               // Extract the AC Audit section
               const auditSectionMatch = body.match(
-                /## AC Audit[\s\S]*?(?=\n## |\n---|\Z|$)/
+                /## AC Audit[\s\S]*?(?=\n## |\n---|$)/
               );
               const auditSection = auditSectionMatch
                 ? auditSectionMatch[0]


### PR DESCRIPTION
## Summary
- Fix JavaScript regex bug in AC Evidence Gate workflow where `\Z` (Python/Ruby syntax) was treated as literal `Z` character
- This caused the audit section extraction to truncate at first `Z` in text (e.g., "Zstd", "SIZE"), falsely reporting missing verdicts
- Replace with `$` which is the correct JS end-of-string anchor

## Test plan
- [ ] Close an issue with `Z` in evidence text (e.g., "Zstd compression")
- [ ] Verify AC Evidence Gate does not reopen the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)