### PR TITLE
feat: add Git tab, fix EditorPanel reactivity, pass messages to TopologyGraph

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,9 @@ import NetworkPanel from "./components/network/NetworkPanel";
 import GalleryPanel from "./components/gallery/GalleryPanel";
 import SettingsPanel from "./components/settings/SettingsPanel";
 import ProfilerPanel from "./components/profiler/ProfilerPanel";
+import BranchSelector from "./components/git/BranchSelector";
+import StagingArea from "./components/git/StagingArea";
+import CommitHistory from "./components/git/CommitHistory";
 import CommandPalette from "./components/shared/CommandPalette";
 import { useIsMobile } from "./hooks/useMediaQuery";
 import { useKeymap, type KeyBinding } from "./shortcuts/keymap";
@@ -81,7 +84,7 @@ export default function App() {
 
 // --- Center Tab Definitions ---
 
-type CenterTabId = "chat" | "editor" | "network" | "teams" | "gallery" | "tasks" | "settings" | "profiler";
+type CenterTabId = "chat" | "editor" | "network" | "teams" | "gallery" | "tasks" | "git" | "settings" | "profiler";
 
 interface TabDef {
   id: CenterTabId;
@@ -96,7 +99,8 @@ const CENTER_TABS: TabDef[] = [
   { id: "teams", label: "Teams", shortcut: "4" },
   { id: "gallery", label: "Gallery", shortcut: "5" },
   { id: "tasks", label: "Tasks", shortcut: "6" },
-  { id: "settings", label: "Settings", shortcut: "7" },
+  { id: "git", label: "Git", shortcut: "7" },
+  { id: "settings", label: "Settings", shortcut: "8" },
 ];
 
 // --- Shell ---
@@ -232,6 +236,19 @@ function CenterPanel(props: { activeTab: CenterTabId; onTabChange: (tab: CenterT
         </Show>
         <Show when={props.activeTab === "tasks"}>
           <TaskPanel />
+        </Show>
+        <Show when={props.activeTab === "git"}>
+          <div style={{ display: "flex", "flex-direction": "column", height: "100%", overflow: "auto" }}>
+            <div style={{ padding: "8px", "border-bottom": "1px solid var(--ctp-surface0)" }}>
+              <BranchSelector />
+            </div>
+            <div style={{ padding: "8px", "border-bottom": "1px solid var(--ctp-surface0)" }}>
+              <StagingArea />
+            </div>
+            <div style={{ flex: "1", overflow: "auto", padding: "8px" }}>
+              <CommitHistory />
+            </div>
+          </div>
         </Show>
         <Show when={props.activeTab === "settings"}>
           <SettingsPanel />

--- a/frontend/src/components/editor/EditorPanel.tsx
+++ b/frontend/src/components/editor/EditorPanel.tsx
@@ -1,4 +1,4 @@
-import { onMount, onCleanup, createSignal, Show } from "solid-js";
+import { createEffect, onCleanup, createSignal, Show } from "solid-js";
 import { EditorState } from "@codemirror/state";
 import { EditorView, lineNumbers } from "@codemirror/view";
 import { javascript } from "@codemirror/lang-javascript";
@@ -98,8 +98,13 @@ export default function EditorPanel(props: EditorPanelProps) {
   const [diffOriginal, _setDiffOriginal] = createSignal("");
   const [diffModified, _setDiffModified] = createSignal("");
 
-  onMount(() => {
-    if (!containerRef) return;
+  createEffect(() => {
+    // Track filePath reactively so editor is created when Show renders the container
+    const filePath = props.filePath;
+    if (!filePath || !containerRef) return;
+
+    // Destroy previous instance if any
+    editorView?.destroy();
 
     const extensions = [
       lineNumbers(),
@@ -108,7 +113,7 @@ export default function EditorPanel(props: EditorPanelProps) {
       EditorState.readOnly.of(props.readOnly ?? false),
     ];
 
-    const lang = props.filePath ? languageFromPath(props.filePath) : null;
+    const lang = languageFromPath(filePath);
     if (lang) extensions.push(lang);
 
     editorView = new EditorView({

--- a/frontend/src/components/teams/TeamsPanel.tsx
+++ b/frontend/src/components/teams/TeamsPanel.tsx
@@ -22,6 +22,11 @@ export default function TeamsPanel() {
     { from: "team-lead", to: "tester" },
   ];
 
+  const messages = [
+    { id: "msg-1", from: "team-lead", to: "researcher", progress: 0.3 },
+    { id: "msg-2", from: "team-lead", to: "implementer", progress: 0.7 },
+  ];
+
   const swimlaneBlocks: SwimlaneBlock[] = [
     { agentName: "team-lead", startMs: 0, endMs: 5000, state: "active", label: "Planning" },
     { agentName: "team-lead", startMs: 5000, endMs: 8000, state: "thinking" },
@@ -109,7 +114,7 @@ export default function TeamsPanel() {
       {/* Content */}
       <div style={{ flex: "1", overflow: "hidden" }}>
         <Show when={viewMode() === "topology"}>
-          <TopologyGraph agents={agents} edges={edges} />
+          <TopologyGraph agents={agents} edges={edges} messages={messages} />
         </Show>
         <Show when={viewMode() === "swimlane"}>
           <div style={{ padding: "8px" }}>


### PR DESCRIPTION
## Summary
- Add Git tab to center panel with BranchSelector, StagingArea, CommitHistory components
- Fix EditorPanel: replace `onMount` with `createEffect` for reactive `filePath` tracking
- Pass message bubble data to TopologyGraph for animated edge visualization

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] Git tab renders with BranchSelector, StagingArea, CommitHistory
- [ ] EditorPanel properly re-initializes when filePath changes
- [ ] TopologyGraph shows animated message bubbles on edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)