### PR TITLE
build: upgrade hecs 0.10→0.11 and ignore eslint major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,6 @@ updates:
       interval: "weekly"
     labels:
       - "type:deps"
+    ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,12 +1183,13 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hecs"
-version = "0.10.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cbc675ee8d97b4d206a985137f8ad59666538f56f906474f554467a63c776d"
+checksum = "f3a2d85ff28b1e1a1c183b6ca9ec1a6b97e7937fb989988a74d9db39760a07b8"
 dependencies = [
- "hashbrown 0.14.5",
- "spin 0.9.8",
+ "foldhash 0.2.0",
+ "hashbrown 0.16.1",
+ "spin 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ zenoh = "1"
 zenoh-shm = "1"
 
 # ECS state engine
-hecs = "0.10"
+hecs = "0.11"
 
 # Database
 limbo = { version = "0.0", features = ["index_experimental"] }

--- a/server/src/ecs/world.rs
+++ b/server/src/ecs/world.rs
@@ -97,7 +97,7 @@ impl EcsWorld {
 
     pub fn query_sessions(&self) -> Vec<SessionComponent> {
         let mut query = self.world.query::<&SessionComponent>();
-        query.iter().map(|(_, s)| (*s).clone()).collect()
+        query.iter().cloned().collect()
     }
 
     pub fn query_session_by_id(&self, session_id: Uuid) -> Option<SessionComponent> {


### PR DESCRIPTION
## Summary
- Upgrade hecs from 0.10 to 0.11 (breaking: `query.iter()` now yields `Q::Item` directly instead of `(Entity, Q::Item)`)
- Adapt `EcsWorld::query_sessions()` to new iterator API
- Add Dependabot ignore rule for eslint major bumps (eslint-plugin-solid only supports eslint <=9)

## Test plan
- [x] `cargo remote -- clippy -p noaide-server` passes (0 warnings)
- [x] All 10 ECS tests pass (`ecs::world::tests::*` + `ecs::systems::tests::*`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)