### PR TITLE
ci: add issue close guard workflow

### DIFF
--- a/.github/workflows/issue-close-guard.yml
+++ b/.github/workflows/issue-close-guard.yml
@@ -1,0 +1,161 @@
+name: Issue Close Guard
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  verify-closure:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const body = issue.body || '';
+            const labels = issue.labels.map(l => l.name);
+
+            // Only check type:feature and type:bug
+            const isTrackable = labels.some(l =>
+              l === 'type:feature' || l === 'type:bug'
+            );
+            if (!isTrackable) return;
+
+            // --- Check 1: status:verified label ---
+            const hasVerified = labels.includes('status:verified');
+
+            // --- Check 2: Incompatible status ---
+            const wrongStatus = labels.filter(l =>
+              l === 'status:blocked' ||
+              l === 'status:ready' ||
+              l === 'status:in-progress'
+            );
+
+            // --- Check 3: Verify-Report comment ---
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number
+            });
+
+            const verifyComments = comments.data.filter(c =>
+              /## Verify-Report/i.test(c.body)
+            );
+            const hasReport = verifyComments.length > 0;
+
+            // --- Check 4: AC-IDs from body must be in report ---
+            const bodyAcIds = [...body.matchAll(/AC-(\d+)/g)].map(m => m[0]);
+            const uniqueAcIds = [...new Set(bodyAcIds)];
+
+            let missingAcs = [];
+            if (hasReport && uniqueAcIds.length > 0) {
+              const reportBody = verifyComments.map(c => c.body).join('\n');
+              missingAcs = uniqueAcIds.filter(ac => !reportBody.includes(ac));
+            }
+
+            // --- Check 5: Commands in report (not just text) ---
+            const hasCommands = verifyComments.some(c =>
+              /`[^`]{3,}`/.test(c.body) &&
+              /Command:|command:|Verify:|pass|fail/i.test(c.body)
+            );
+
+            // --- Check 6: scope:full needs deploy evidence ---
+            const isScopeFull = labels.includes('scope:full');
+            const hasDeployEvidence = verifyComments.some(c =>
+              /ssh |systemctl |curl.*health|docker |deploy|System\/Artifact/i.test(c.body)
+            );
+
+            // Collect failures
+            const failures = [];
+            if (!hasVerified) {
+              failures.push('Missing `status:verified` label');
+            }
+            if (wrongStatus.length > 0) {
+              failures.push(`Incompatible status labels: ${wrongStatus.join(', ')}`);
+            }
+            if (!hasReport) {
+              failures.push('No `## Verify-Report` comment found');
+            }
+            if (missingAcs.length > 0) {
+              failures.push(`ACs missing in Verify-Report: ${missingAcs.join(', ')}`);
+            }
+            if (hasReport && !hasCommands) {
+              failures.push('Verify-Report has no concrete commands/evidence');
+            }
+            if (isScopeFull && !hasDeployEvidence) {
+              failures.push('scope:full requires deploy/system evidence in Verify-Report');
+            }
+
+            if (failures.length > 0) {
+              // REOPEN
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'open'
+              });
+
+              // Remove wrong labels
+              for (const label of ['status:completed', 'status:verified']) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: label
+                  });
+                } catch {}
+              }
+
+              // Add needs-evidence
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  labels: ['quality:needs-evidence']
+                });
+              } catch {}
+
+              // Comment with instructions
+              const acList = uniqueAcIds.length > 0
+                ? `\n\n**Expected ACs in report:** ${uniqueAcIds.join(', ')}`
+                : '';
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: [
+                  '## Issue Automatically Reopened',
+                  '',
+                  'This issue was closed without sufficient verification evidence.',
+                  '',
+                  '**Missing requirements:**',
+                  ...failures.map(f => `- ${f}`),
+                  acList,
+                  '',
+                  '**To close this issue correctly:**',
+                  '1. Post a `## Verify-Report` comment (template below)',
+                  '2. The report must contain ALL AC-IDs from the issue body',
+                  '3. The report must contain concrete commands with output',
+                  '4. Set the `status:verified` label',
+                  '5. Close the issue again',
+                  '',
+                  '```markdown',
+                  '## Verify-Report',
+                  '| AC-ID | Result | Command | Output | Artifact |',
+                  '|-------|--------|---------|--------|----------|',
+                  '| AC-1  | pass/fail | `<concrete command>` | <output> | <path> |',
+                  '',
+                  '**NOT Tested:** [what + why]',
+                  '**Confidence:** [0-100% + 1 sentence]',
+                  '```'
+                ].join('\n')
+              });
+
+              core.setFailed(`Issue #${issue.number} reopened: missing verification evidence`);
+            }


### PR DESCRIPTION
## Summary
- Adds GitHub Action that automatically reopens issues closed without proper verification evidence
- Checks for `status:verified` label, `## Verify-Report` comment with AC-IDs, and concrete commands
- Part of 5-gate verification hooks system (Gate 5)

## Test plan
- [ ] Create test issue #69 and attempt to close without evidence → should be reopened by workflow
- [ ] Post proper Verify-Report, add label, close → should stay closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)