### PR TITLE
test(network): add 38 unit tests for network tab helpers

### DIFF
--- a/frontend/src/components/network/InterceptQueue.test.ts
+++ b/frontend/src/components/network/InterceptQueue.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { parseRequestBody, parseResponseBody } from "./InterceptQueue";
+
+describe("parseRequestBody", () => {
+  it("parses Anthropic request body", () => {
+    const body = JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 8192,
+      system: "You are a helpful assistant.",
+      messages: [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi there!" },
+      ],
+    });
+    const result = parseRequestBody(body);
+    expect(result).not.toBeNull();
+    expect(result!.model).toBe("claude-sonnet-4-20250514");
+    expect(result!.maxTokens).toBe(8192);
+    expect(result!.system).toBe("You are a helpful assistant.");
+    expect(result!.messages).toHaveLength(2);
+    expect(result!.messages[0]).toEqual({ role: "user", content: "Hello" });
+  });
+
+  it("handles array system prompt", () => {
+    const body = JSON.stringify({
+      model: "gpt-4",
+      system: [{ text: "Part 1" }, { text: "Part 2" }],
+      messages: [],
+    });
+    const result = parseRequestBody(body);
+    expect(result).not.toBeNull();
+    expect(result!.system).toBe("Part 1\nPart 2");
+  });
+
+  it("handles content blocks in messages", () => {
+    const body = JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Look at this:" },
+            { type: "image" },
+          ],
+        },
+      ],
+    });
+    const result = parseRequestBody(body);
+    expect(result).not.toBeNull();
+    expect(result!.messages[0].content).toBe("Look at this:\n[image]");
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(parseRequestBody("not json")).toBeNull();
+  });
+
+  it("handles empty body", () => {
+    expect(parseRequestBody("{}")).not.toBeNull();
+    expect(parseRequestBody("{}")).toEqual({
+      model: "",
+      maxTokens: 0,
+      system: "",
+      messages: [],
+    });
+  });
+});
+
+describe("parseResponseBody", () => {
+  it("parses Anthropic response body", () => {
+    const body = JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      type: "message",
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: "Hello world" }],
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+    const result = parseResponseBody(body);
+    expect(result).not.toBeNull();
+    expect(result!.model).toBe("claude-sonnet-4-20250514");
+    expect(result!.type).toBe("message");
+    expect(result!.stopReason).toBe("end_turn");
+    expect(result!.content).toBe("Hello world");
+    expect(result!.inputTokens).toBe(100);
+    expect(result!.outputTokens).toBe(50);
+  });
+
+  it("handles multiple content blocks", () => {
+    const body = JSON.stringify({
+      content: [
+        { type: "thinking", text: "Let me think..." },
+        { type: "text", text: "Here is my answer" },
+      ],
+      usage: {},
+    });
+    const result = parseResponseBody(body);
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe("Let me think...\nHere is my answer");
+  });
+
+  it("handles content blocks without text", () => {
+    const body = JSON.stringify({
+      content: [{ type: "tool_use" }],
+      usage: {},
+    });
+    const result = parseResponseBody(body);
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe("[tool_use]");
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(parseResponseBody("not json")).toBeNull();
+  });
+
+  it("handles missing fields gracefully", () => {
+    const result = parseResponseBody("{}");
+    expect(result).not.toBeNull();
+    expect(result!.model).toBe("");
+    expect(result!.stopReason).toBe("");
+    expect(result!.inputTokens).toBe(0);
+  });
+});

--- a/frontend/src/components/network/InterceptQueue.tsx
+++ b/frontend/src/components/network/InterceptQueue.tsx
@@ -121,6 +121,8 @@ const contentBlockStyle = {
   overflow: "auto",
 };
 
+export { parseRequestBody, parseResponseBody };
+
 export default function InterceptQueue(props: InterceptQueueProps) {
   const [pending, setPending] = createSignal<PendingIntercept[]>([]);
   const [pendingResponses, setPendingResponses] = createSignal<

--- a/frontend/src/components/network/RequestDetail.test.ts
+++ b/frontend/src/components/network/RequestDetail.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import {
+  tryParseJson,
+  parseSseEvents,
+  extractResponseContent,
+} from "./RequestDetail";
+
+describe("tryParseJson", () => {
+  it("parses valid JSON", () => {
+    expect(tryParseJson('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(tryParseJson("not json")).toBeNull();
+  });
+
+  it("parses arrays", () => {
+    expect(tryParseJson("[1,2,3]")).toEqual([1, 2, 3]);
+  });
+
+  it("returns null for empty string", () => {
+    expect(tryParseJson("")).toBeNull();
+  });
+});
+
+describe("parseSseEvents", () => {
+  it("parses single event", () => {
+    const sse = "event: message_start\ndata: {\"type\":\"message_start\"}\n\n";
+    const events = parseSseEvents(sse);
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toBe("message_start");
+    expect(events[0].data).toEqual({ type: "message_start" });
+  });
+
+  it("parses multiple events", () => {
+    const sse = [
+      "event: message_start",
+      'data: {"type":"message_start"}',
+      "",
+      "event: content_block_delta",
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello"}}',
+      "",
+    ].join("\n");
+    const events = parseSseEvents(sse);
+    expect(events).toHaveLength(2);
+    expect(events[0].event).toBe("message_start");
+    expect(events[1].event).toBe("content_block_delta");
+  });
+
+  it("handles non-JSON data", () => {
+    const sse = "event: ping\ndata: keep-alive\n\n";
+    const events = parseSseEvents(sse);
+    expect(events).toHaveLength(1);
+    expect(events[0].data).toBe("keep-alive");
+  });
+
+  it("handles leftover data without trailing blank line", () => {
+    const sse = "event: done\ndata: {\"fin\":true}";
+    const events = parseSseEvents(sse);
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toBe("done");
+    expect(events[0].data).toEqual({ fin: true });
+  });
+
+  it("defaults event name to 'data'", () => {
+    const sse = 'data: {"msg":"hi"}\n\n';
+    const events = parseSseEvents(sse);
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toBe("data");
+  });
+});
+
+describe("extractResponseContent", () => {
+  it("extracts model and text from SSE stream", () => {
+    const sse = [
+      "event: message_start",
+      'data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","usage":{"input_tokens":100}}}',
+      "",
+      "event: content_block_delta",
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello "}}',
+      "",
+      "event: content_block_delta",
+      'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"world"}}',
+      "",
+      "event: message_delta",
+      'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":50}}',
+      "",
+    ].join("\n");
+
+    const result = extractResponseContent(sse);
+    expect(result.model).toBe("claude-sonnet-4-20250514");
+    expect(result.text).toBe("Hello world");
+    expect(result.inputTokens).toBe(100);
+    expect(result.outputTokens).toBe(50);
+    expect(result.stopReason).toBe("end_turn");
+  });
+
+  it("extracts thinking blocks", () => {
+    const sse = [
+      "event: message_start",
+      'data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","usage":{"input_tokens":10}}}',
+      "",
+      "event: content_block_delta",
+      'data: {"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"Let me think..."}}',
+      "",
+    ].join("\n");
+
+    const result = extractResponseContent(sse);
+    expect(result.thinking).toBe("Let me think...");
+  });
+
+  it("handles empty SSE", () => {
+    const result = extractResponseContent("");
+    expect(result.model).toBe("");
+    expect(result.text).toBe("");
+    expect(result.inputTokens).toBe(0);
+    expect(result.outputTokens).toBe(0);
+  });
+});

--- a/frontend/src/components/network/RequestDetail.tsx
+++ b/frontend/src/components/network/RequestDetail.tsx
@@ -15,6 +15,7 @@ interface RequestDetailProps {
 type Tab = "response" | "request" | "headers";
 
 export type { RequestDetailFull };
+export { tryParseJson, parseSseEvents, extractResponseContent };
 
 /** Try to parse JSON and pretty-print it. */
 function tryParseJson(text: string): unknown | null {

--- a/frontend/src/components/network/RequestRow.test.ts
+++ b/frontend/src/components/network/RequestRow.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  statusColor,
+  statusColorDark,
+  formatSize,
+  formatTime,
+  shortUrl,
+} from "./RequestRow";
+
+describe("statusColor", () => {
+  it("returns green for 2xx", () => {
+    expect(statusColor(200)).toBe("#a6e3a1");
+    expect(statusColor(201)).toBe("#a6e3a1");
+    expect(statusColor(299)).toBe("#a6e3a1");
+  });
+
+  it("returns blue for 3xx", () => {
+    expect(statusColor(301)).toBe("#89b4fa");
+    expect(statusColor(304)).toBe("#89b4fa");
+  });
+
+  it("returns yellow for 4xx", () => {
+    expect(statusColor(400)).toBe("#f9e2af");
+    expect(statusColor(401)).toBe("#f9e2af");
+    expect(statusColor(404)).toBe("#f9e2af");
+  });
+
+  it("returns red for 5xx", () => {
+    expect(statusColor(500)).toBe("#f38ba8");
+    expect(statusColor(503)).toBe("#f38ba8");
+  });
+
+  it("returns overlay for unknown codes", () => {
+    expect(statusColor(0)).toBe("#a6adc8");
+    expect(statusColor(100)).toBe("#a6adc8");
+  });
+});
+
+describe("statusColorDark", () => {
+  it("returns dark green for 2xx", () => {
+    expect(statusColorDark(200)).toBe("#40a02b");
+  });
+
+  it("returns dark red for 5xx", () => {
+    expect(statusColorDark(500)).toBe("#d20f39");
+  });
+});
+
+describe("formatSize", () => {
+  it("formats bytes", () => {
+    expect(formatSize(0)).toBe("0B");
+    expect(formatSize(512)).toBe("512B");
+    expect(formatSize(1023)).toBe("1023B");
+  });
+
+  it("formats kilobytes", () => {
+    expect(formatSize(1024)).toBe("1.0KB");
+    expect(formatSize(1536)).toBe("1.5KB");
+    expect(formatSize(55724)).toBe("54.4KB");
+  });
+
+  it("formats megabytes", () => {
+    expect(formatSize(1048576)).toBe("1.0MB");
+    expect(formatSize(5242880)).toBe("5.0MB");
+  });
+});
+
+describe("formatTime", () => {
+  it("formats timestamp as HH:MM:SS", () => {
+    // 2026-03-06T10:30:45 UTC
+    const ts = new Date("2026-03-06T10:30:45Z").getTime();
+    const result = formatTime(ts);
+    // We can't know the exact local time, but format should be HH:MM:SS
+    expect(result).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+  });
+
+  it("pads single digits", () => {
+    // Midnight UTC
+    const ts = new Date("2026-01-01T00:01:05Z").getTime();
+    const result = formatTime(ts);
+    expect(result).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+  });
+});
+
+describe("shortUrl", () => {
+  it("extracts pathname from URL", () => {
+    expect(shortUrl("https://api.anthropic.com/v1/messages")).toBe(
+      "/v1/messages",
+    );
+  });
+
+  it("handles tunnel protocol", () => {
+    expect(shortUrl("tunnel://api.anthropic.com:443")).toBe(
+      "api.anthropic.com:443",
+    );
+  });
+
+  it("returns raw string for invalid URL", () => {
+    expect(shortUrl("not-a-url")).toBe("not-a-url");
+  });
+
+  it("extracts pathname only (no query params)", () => {
+    // shortUrl uses URL.pathname which strips query params
+    expect(
+      shortUrl("https://chatgpt.com/backend-api/codex/responses?foo=bar"),
+    ).toBe("/backend-api/codex/responses");
+  });
+});

--- a/frontend/src/components/network/RequestRow.tsx
+++ b/frontend/src/components/network/RequestRow.tsx
@@ -65,6 +65,7 @@ function shortUrl(url: string): string {
 }
 
 export type { ApiRequest };
+export { statusColor, statusColorDark, formatSize, formatTime, shortUrl };
 
 export default function RequestRow(props: RequestRowProps) {
   const [hovered, setHovered] = createSignal(false);


### PR DESCRIPTION
## Summary
- Add 38 unit tests for network tab pure helper functions (RequestRow, RequestDetail, InterceptQueue)
- Export helper functions from components to enable isolated unit testing without SolidJS rendering
- All tests verify status color mapping, size/time formatting, URL parsing, SSE event parsing, and request/response body parsing

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — 0 errors
- [x] `npx vitest run src/components/network/` — 38/38 pass
- [x] `npx vitest run` — 102/102 pass (full suite)
- [x] No regressions in existing tests

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)