### PR TITLE
feat(proxy): Full Network Proxy Phase 0.3-1.8 (11 increments)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2341,6 +2341,7 @@ dependencies = [
  "rcgen",
  "regex",
  "reqwest",
+ "ring",
  "rmp-serde",
  "rustls",
  "rustls-native-certs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ wtransport = "0.7"
 quinn = "0.11"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 rustls-pemfile = "2"
+ring = "0.17"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/frontend/src/components/network/AuditPanel.tsx
+++ b/frontend/src/components/network/AuditPanel.tsx
@@ -1,0 +1,116 @@
+import { createSignal, For, Show, onMount, onCleanup } from "solid-js";
+import { useSession } from "../../App";
+
+interface AuditEntry {
+  id: string;
+  session_id: string | null;
+  model: string;
+  provider: string;
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number;
+  timestamp: number;
+  latency_ms: number;
+  method: string;
+  url: string;
+}
+
+export default function AuditPanel() {
+  const store = useSession();
+  const [entries, setEntries] = createSignal<AuditEntry[]>([]);
+
+  async function fetchAudit() {
+    const base = store.state.httpApiUrl;
+    if (!base) return;
+    const sid = store.state.activeSessionId;
+    const url = sid
+      ? `${base}/api/proxy/audit?session_id=${sid}&limit=50`
+      : `${base}/api/proxy/audit?limit=50`;
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        const data = await res.json();
+        setEntries(data.entries || []);
+      }
+    } catch { /* ignore */ }
+  }
+
+  function exportCsv() {
+    const base = store.state.httpApiUrl;
+    if (!base) return;
+    window.open(`${base}/api/proxy/audit/export?format=csv&limit=10000`, "_blank");
+  }
+
+  onMount(() => {
+    void fetchAudit();
+    const interval = setInterval(function() { void fetchAudit(); }, 10000);
+    onCleanup(() => clearInterval(interval));
+  });
+
+  const totalCost = () => entries().reduce((sum, e) => sum + e.cost_usd, 0);
+
+  return (
+    <div
+      data-testid="audit-panel"
+      style={{
+        padding: "8px 12px",
+        "border-top": "1px solid var(--ctp-surface0)",
+        background: "var(--ctp-mantle)",
+        "max-height": "300px",
+        overflow: "auto",
+      }}
+    >
+      <div style={{ display: "flex", "justify-content": "space-between", "align-items": "center", "margin-bottom": "6px" }}>
+        <div style={{ "font-size": "11px", "font-weight": "600", color: "var(--ctp-text)" }}>
+          Audit Log — ${totalCost().toFixed(4)}
+        </div>
+        <button
+          data-testid="audit-export-csv"
+          onClick={exportCsv}
+          style={{
+            padding: "2px 6px",
+            "font-size": "9px",
+            background: "var(--ctp-surface0)",
+            border: "1px solid var(--ctp-surface1)",
+            "border-radius": "3px",
+            color: "var(--ctp-subtext0)",
+            cursor: "pointer",
+          }}
+        >
+          CSV
+        </button>
+      </div>
+
+      <Show when={entries().length > 0} fallback={<div style={{ "font-size": "10px", color: "var(--ctp-overlay0)" }}>No audit entries</div>}>
+        <table style={{ width: "100%", "font-size": "10px", "border-collapse": "collapse" }}>
+          <thead>
+            <tr style={{ color: "var(--ctp-overlay0)", "text-align": "left" }}>
+              <th style={{ padding: "2px 4px" }}>Time</th>
+              <th style={{ padding: "2px 4px" }}>Model</th>
+              <th style={{ padding: "2px 4px" }}>In</th>
+              <th style={{ padding: "2px 4px" }}>Out</th>
+              <th style={{ padding: "2px 4px" }}>Cost</th>
+              <th style={{ padding: "2px 4px" }}>Latency</th>
+            </tr>
+          </thead>
+          <tbody>
+            <For each={entries()}>
+              {(entry) => (
+                <tr style={{ "border-top": "1px solid var(--ctp-surface0)" }}>
+                  <td style={{ padding: "2px 4px", color: "var(--ctp-overlay1)" }}>
+                    {new Date(entry.timestamp).toLocaleTimeString()}
+                  </td>
+                  <td style={{ padding: "2px 4px", color: "var(--ctp-blue)" }}>{entry.model}</td>
+                  <td style={{ padding: "2px 4px", color: "var(--ctp-text)" }}>{entry.input_tokens}</td>
+                  <td style={{ padding: "2px 4px", color: "var(--ctp-text)" }}>{entry.output_tokens}</td>
+                  <td style={{ padding: "2px 4px", color: "var(--ctp-green)" }}>${entry.cost_usd.toFixed(4)}</td>
+                  <td style={{ padding: "2px 4px", color: "var(--ctp-overlay1)" }}>{entry.latency_ms}ms</td>
+                </tr>
+              )}
+            </For>
+          </tbody>
+        </table>
+      </Show>
+    </div>
+  );
+}

--- a/frontend/src/components/network/InjectPanel.tsx
+++ b/frontend/src/components/network/InjectPanel.tsx
@@ -1,0 +1,133 @@
+import { createSignal, For, onMount } from "solid-js";
+import { useSession } from "../../App";
+
+const PRESETS = [
+  { id: "noaide_context", label: "noaide Context" },
+  { id: "anti_laziness", label: "Anti-Laziness" },
+  { id: "verify_evidence", label: "Verify Evidence" },
+  { id: "speed", label: "Speed" },
+  { id: "verbose", label: "Verbose" },
+  { id: "german_only", label: "German Only" },
+] as const;
+
+export default function InjectPanel() {
+  const store = useSession();
+  const [activePresets, setActivePresets] = createSignal<string[]>(["noaide_context"]);
+  const [customText, setCustomText] = createSignal("");
+
+  async function fetchConfig() {
+    const base = store.state.httpApiUrl;
+    const sid = store.state.activeSessionId;
+    if (!base || !sid) return;
+    try {
+      const res = await fetch(`${base}/api/proxy/inject/${sid}`);
+      if (res.ok) {
+        const data = await res.json();
+        setActivePresets(data.presets || ["noaide_context"]);
+        setCustomText(data.custom_text || "");
+      }
+    } catch { /* ignore */ }
+  }
+
+  async function saveConfig() {
+    const base = store.state.httpApiUrl;
+    const sid = store.state.activeSessionId;
+    if (!base || !sid) return;
+    try {
+      await fetch(`${base}/api/proxy/inject/${sid}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          presets: activePresets(),
+          custom_text: customText() || null,
+        }),
+      });
+    } catch { /* ignore */ }
+  }
+
+  function togglePreset(presetId: string) {
+    const current = activePresets();
+    if (current.includes(presetId)) {
+      setActivePresets(current.filter((p) => p !== presetId));
+    } else {
+      setActivePresets([...current, presetId]);
+    }
+    void saveConfig();
+  }
+
+  onMount(() => {
+    void fetchConfig();
+  });
+
+  return (
+    <div
+      data-testid="inject-panel"
+      style={{
+        padding: "8px 12px",
+        "border-top": "1px solid var(--ctp-surface0)",
+        background: "var(--ctp-mantle)",
+      }}
+    >
+      <div
+        style={{
+          "font-size": "11px",
+          "font-weight": "600",
+          color: "var(--ctp-text)",
+          "margin-bottom": "6px",
+        }}
+      >
+        System Prompt Injection
+      </div>
+
+      {/* Preset checkboxes */}
+      <div style={{ display: "flex", gap: "6px", "flex-wrap": "wrap", "margin-bottom": "6px" }}>
+        <For each={PRESETS}>
+          {(preset) => (
+            <label
+              style={{
+                display: "flex",
+                "align-items": "center",
+                gap: "3px",
+                "font-size": "10px",
+                color: activePresets().includes(preset.id)
+                  ? "var(--ctp-text)"
+                  : "var(--ctp-overlay0)",
+                cursor: "pointer",
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={activePresets().includes(preset.id)}
+                onChange={() => togglePreset(preset.id)}
+                style={{ width: "12px", height: "12px" }}
+              />
+              {preset.label}
+            </label>
+          )}
+        </For>
+      </div>
+
+      {/* Custom text */}
+      <textarea
+        data-testid="inject-custom-text"
+        placeholder="Custom injection text..."
+        value={customText()}
+        onInput={(e) => setCustomText(e.currentTarget.value)}
+        onBlur={() => void saveConfig()}
+        style={{
+          width: "100%",
+          "min-height": "40px",
+          padding: "4px 6px",
+          "font-size": "10px",
+          "font-family": "var(--font-mono)",
+          background: "var(--ctp-surface0)",
+          border: "1px solid var(--ctp-surface1)",
+          "border-radius": "3px",
+          color: "var(--ctp-text)",
+          resize: "vertical",
+          outline: "none",
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/network/NetworkPanel.tsx
+++ b/frontend/src/components/network/NetworkPanel.tsx
@@ -13,6 +13,7 @@ export default function NetworkPanel() {
   const [statusFilter, setStatusFilter] = createSignal<string>("all");
   const [interceptMode, setInterceptMode] = createSignal<"auto" | "manual">("auto");
   const [pendingCount, setPendingCount] = createSignal(0);
+  const [categoryFilter, setCategoryFilter] = createSignal<string>("all");
 
   async function fetchInterceptStatus() {
     const base = store.state.httpApiUrl;
@@ -114,6 +115,7 @@ export default function NetworkPanel() {
     const query = filter().toLowerCase();
     const method = methodFilter();
     const status = statusFilter();
+    const cat = categoryFilter();
 
     if (query) {
       items = items.filter(
@@ -133,6 +135,10 @@ export default function NetworkPanel() {
       items = items.filter((r) => r.statusCode >= 400 && r.statusCode < 500);
     } else if (status === "5xx") {
       items = items.filter((r) => r.statusCode >= 500);
+    }
+
+    if (cat !== "all") {
+      items = items.filter((r) => (r.category || "Unknown") === cat);
     }
 
     return items;
@@ -298,6 +304,40 @@ export default function NetworkPanel() {
           </button>
         </Show>
 
+        {/* Quick-Block selected domain */}
+        <Show when={selectedRequest()}>
+          <button
+            data-testid="quick-block-btn"
+            onClick={async () => {
+              const base = store.state.httpApiUrl;
+              const sid = store.state.activeSessionId;
+              const req = selectedRequest();
+              if (!base || !sid || !req) return;
+              try {
+                const domain = new URL(req.url).hostname;
+                await fetch(`${base}/api/proxy/quick-block`, {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ session_id: sid, domain }),
+                });
+              } catch { /* ignore */ }
+            }}
+            style={{
+              padding: "3px 8px",
+              "font-size": "10px",
+              background: "var(--ctp-red)",
+              border: "none",
+              "border-radius": "4px",
+              color: "var(--ctp-base)",
+              cursor: "pointer",
+              "white-space": "nowrap",
+              "font-weight": "600",
+            }}
+          >
+            Block
+          </button>
+        </Show>
+
         {/* HAR Export */}
         <button
           data-testid="har-export-btn"
@@ -375,11 +415,74 @@ export default function NetworkPanel() {
         </div>
       </Show>
 
+      {/* Category Filter Chips */}
+      <div
+        data-testid="category-chips"
+        style={{
+          display: "flex",
+          gap: "4px",
+          padding: "4px 12px",
+          "border-bottom": "1px solid var(--ctp-surface0)",
+          background: "var(--ctp-mantle)",
+          "flex-wrap": "wrap",
+        }}
+      >
+        <For each={["All", "Api", "Telemetry", "Auth", "Update", "Git", "Unknown"] as const}>
+          {(cat) => {
+            const count = () =>
+              cat === "All"
+                ? requests().length
+                : requests().filter((r) => (r.category || "Unknown") === cat).length;
+            return (
+              <button
+                data-testid={`category-chip-${cat.toLowerCase()}`}
+                onClick={() => setCategoryFilter(cat === "All" ? "all" : cat)}
+                style={{
+                  padding: "2px 8px",
+                  "font-size": "10px",
+                  "border-radius": "10px",
+                  border: "1px solid",
+                  "border-color":
+                    (categoryFilter() === "all" && cat === "All") ||
+                    categoryFilter() === cat
+                      ? "var(--ctp-blue)"
+                      : "var(--ctp-surface1)",
+                  background:
+                    (categoryFilter() === "all" && cat === "All") ||
+                    categoryFilter() === cat
+                      ? "var(--ctp-blue)"
+                      : "var(--ctp-surface0)",
+                  color:
+                    (categoryFilter() === "all" && cat === "All") ||
+                    categoryFilter() === cat
+                      ? "var(--ctp-base)"
+                      : "var(--ctp-subtext0)",
+                  cursor: "pointer",
+                  "font-weight": "500",
+                }}
+              >
+                {cat}
+                <Show when={count() > 0}>
+                  <span
+                    style={{
+                      "margin-left": "4px",
+                      opacity: "0.7",
+                    }}
+                  >
+                    {count()}
+                  </span>
+                </Show>
+              </button>
+            );
+          }}
+        </For>
+      </div>
+
       {/* Column headers */}
       <div
         style={{
           display: "grid",
-          "grid-template-columns": "60px 58px 1fr 50px 60px 60px 160px",
+          "grid-template-columns": "12px 60px 58px 1fr 50px 60px 60px 160px",
           gap: "8px",
           padding: "4px 12px",
           "font-size": "10px",
@@ -390,6 +493,7 @@ export default function NetworkPanel() {
           "border-bottom": "1px solid var(--ctp-surface0)",
         }}
       >
+        <span></span>
         <span>Method</span>
         <span>Time</span>
         <span>URL</span>

--- a/frontend/src/components/network/NetworkPanel.tsx
+++ b/frontend/src/components/network/NetworkPanel.tsx
@@ -3,6 +3,7 @@ import { useSession } from "../../App";
 import RequestRow from "./RequestRow";
 import RequestDetail, { type RequestDetailFull } from "./RequestDetail";
 import InterceptQueue from "./InterceptQueue";
+import RuleEditor from "./RuleEditor";
 
 export default function NetworkPanel() {
   const store = useSession();
@@ -14,6 +15,7 @@ export default function NetworkPanel() {
   const [interceptMode, setInterceptMode] = createSignal<"auto" | "manual">("auto");
   const [pendingCount, setPendingCount] = createSignal(0);
   const [categoryFilter, setCategoryFilter] = createSignal<string>("all");
+  const [showRules, setShowRules] = createSignal(false);
 
   async function fetchInterceptStatus() {
     const base = store.state.httpApiUrl;
@@ -165,6 +167,37 @@ export default function NetworkPanel() {
     if (!id) return null;
     return requests().find((r) => r.id === id) ?? null;
   });
+
+  async function quickBlockDomain(domain: string) {
+    const base = store.state.httpApiUrl;
+    const sid = store.state.activeSessionId;
+    if (!base || !sid) return;
+    try {
+      await fetch(`${base}/api/proxy/quick-block`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ session_id: sid, domain }),
+      });
+    } catch { /* ignore */ }
+  }
+
+  async function blockCategory(category: string) {
+    const base = store.state.httpApiUrl;
+    const sid = store.state.activeSessionId;
+    if (!base || !sid) return;
+    try {
+      await fetch(`${base}/api/proxy/network-rules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          session_id: sid,
+          category_filter: category,
+          action: "block",
+          priority: 50,
+        }),
+      });
+    } catch { /* ignore */ }
+  }
 
   return (
     <div
@@ -335,6 +368,26 @@ export default function NetworkPanel() {
             }}
           >
             Block
+          </button>
+        </Show>
+
+        {/* Rules Toggle */}
+        <Show when={store.state.activeSessionId}>
+          <button
+            data-testid="rules-toggle-btn"
+            onClick={() => setShowRules(!showRules())}
+            style={{
+              padding: "3px 8px",
+              "font-size": "10px",
+              background: showRules() ? "var(--ctp-blue)" : "var(--ctp-surface0)",
+              border: "1px solid var(--ctp-surface1)",
+              "border-radius": "4px",
+              color: showRules() ? "var(--ctp-base)" : "var(--ctp-subtext0)",
+              cursor: "pointer",
+              "white-space": "nowrap",
+            }}
+          >
+            Rules
           </button>
         </Show>
 
@@ -517,6 +570,11 @@ export default function NetworkPanel() {
         />
       </Show>
 
+      {/* Rules Editor Panel */}
+      <Show when={showRules() && store.state.activeSessionId}>
+        <RuleEditor />
+      </Show>
+
       {/* Request list */}
       <div
         style={{
@@ -550,6 +608,12 @@ export default function NetworkPanel() {
                 onClick={() => selectRequest(request.id)}
                 timelineStart={timelineStart()}
                 timelineDuration={timelineDuration()}
+                onQuickBlock={(domain) => {
+                  void quickBlockDomain(domain);
+                }}
+                onBlockCategory={(category) => {
+                  void blockCategory(category);
+                }}
               />
             )}
           </For>

--- a/frontend/src/components/network/NetworkPanel.tsx
+++ b/frontend/src/components/network/NetworkPanel.tsx
@@ -16,6 +16,34 @@ export default function NetworkPanel() {
   const [pendingCount, setPendingCount] = createSignal(0);
   const [categoryFilter, setCategoryFilter] = createSignal<string>("all");
   const [showRules, setShowRules] = createSignal(false);
+  const [proxyMode, setProxyModeSignal] = createSignal("auto");
+
+  async function fetchProxyMode() {
+    const base = store.state.httpApiUrl;
+    const sid = store.state.activeSessionId;
+    if (!base || !sid) return;
+    try {
+      const res = await fetch(`${base}/api/proxy/mode/${sid}`);
+      if (res.ok) {
+        const data = await res.json();
+        setProxyModeSignal(data.mode || "auto");
+      }
+    } catch { /* ignore */ }
+  }
+
+  async function setProxyMode(mode: string) {
+    const base = store.state.httpApiUrl;
+    const sid = store.state.activeSessionId;
+    if (!base || !sid) return;
+    try {
+      await fetch(`${base}/api/proxy/mode/${sid}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode }),
+      });
+      setProxyModeSignal(mode);
+    } catch { /* ignore */ }
+  }
 
   async function fetchInterceptStatus() {
     const base = store.state.httpApiUrl;
@@ -105,6 +133,7 @@ export default function NetworkPanel() {
   onMount(() => {
     fetchRequests();
     fetchInterceptStatus();
+    void fetchProxyMode();
     const interval = setInterval(() => {
       fetchRequests();
       fetchInterceptStatus();
@@ -369,6 +398,51 @@ export default function NetworkPanel() {
           >
             Block
           </button>
+        </Show>
+
+        {/* Proxy Mode Selector */}
+        <Show when={store.state.activeSessionId}>
+          <div
+            data-testid="proxy-mode-selector"
+            style={{
+              display: "flex",
+              "border-radius": "4px",
+              overflow: "hidden",
+              border: "1px solid var(--ctp-surface1)",
+            }}
+          >
+            <For each={["auto", "manual", "custom", "pure", "lockdown"] as const}>
+              {(mode) => (
+                <button
+                  data-testid={`mode-${mode}`}
+                  onClick={() => {
+                    void setProxyMode(mode);
+                  }}
+                  style={{
+                    padding: "2px 6px",
+                    "font-size": "9px",
+                    border: "none",
+                    background:
+                      proxyMode() === mode
+                        ? mode === "lockdown"
+                          ? "var(--ctp-red)"
+                          : mode === "pure"
+                            ? "var(--ctp-green)"
+                            : "var(--ctp-blue)"
+                        : "var(--ctp-surface0)",
+                    color:
+                      proxyMode() === mode
+                        ? "var(--ctp-base)"
+                        : "var(--ctp-overlay0)",
+                    cursor: "pointer",
+                    "text-transform": "capitalize",
+                  }}
+                >
+                  {mode === "lockdown" ? "Lock" : mode.charAt(0).toUpperCase() + mode.slice(1)}
+                </button>
+              )}
+            </For>
+          </div>
         </Show>
 
         {/* Rules Toggle */}

--- a/frontend/src/components/network/RateLimitPanel.tsx
+++ b/frontend/src/components/network/RateLimitPanel.tsx
@@ -1,0 +1,103 @@
+import { createSignal, For, Show, onMount, onCleanup } from "solid-js";
+import { useSession } from "../../App";
+
+interface KeyStatus {
+  id: string;
+  provider: string;
+  label: string;
+  active: boolean;
+  rate_limit_5h: number;
+  rate_limit_7d: number;
+  request_count: number;
+}
+
+export default function RateLimitPanel() {
+  const store = useSession();
+  const [keys, setKeys] = createSignal<KeyStatus[]>([]);
+
+  async function fetchStatus() {
+    const base = store.state.httpApiUrl;
+    if (!base) return;
+    try {
+      const res = await fetch(`${base}/api/proxy/keys/status`);
+      if (res.ok) {
+        const data = await res.json();
+        setKeys(data.keys || []);
+      }
+    } catch { /* ignore */ }
+  }
+
+  onMount(() => {
+    void fetchStatus();
+    const interval = setInterval(function() { void fetchStatus(); }, 5000);
+    onCleanup(() => clearInterval(interval));
+  });
+
+  function barColor(pct: number): string {
+    if (pct >= 80) return "var(--ctp-red)";
+    if (pct >= 50) return "var(--ctp-yellow)";
+    return "var(--ctp-green)";
+  }
+
+  return (
+    <div
+      data-testid="rate-limit-panel"
+      style={{
+        padding: "8px 12px",
+        "border-top": "1px solid var(--ctp-surface0)",
+        background: "var(--ctp-mantle)",
+      }}
+    >
+      <div style={{ "font-size": "11px", "font-weight": "600", color: "var(--ctp-text)", "margin-bottom": "6px" }}>
+        Rate Limits
+      </div>
+
+      <Show when={keys().length > 0} fallback={<div style={{ "font-size": "10px", color: "var(--ctp-overlay0)" }}>No API keys configured</div>}>
+        <For each={keys()}>
+          {(key) => (
+            <div style={{ "margin-bottom": "6px" }}>
+              <div style={{ display: "flex", "justify-content": "space-between", "font-size": "10px", "margin-bottom": "2px" }}>
+                <span style={{ color: key.active ? "var(--ctp-text)" : "var(--ctp-overlay0)" }}>
+                  {key.label} ({key.provider})
+                </span>
+                <span style={{ color: "var(--ctp-overlay0)" }}>{key.request_count} reqs</span>
+              </div>
+              {/* 5h bar */}
+              <div style={{ display: "flex", "align-items": "center", gap: "4px", "margin-bottom": "1px" }}>
+                <span style={{ "font-size": "8px", color: "var(--ctp-overlay0)", width: "20px" }}>5h</span>
+                <div style={{ flex: "1", height: "6px", background: "var(--ctp-surface0)", "border-radius": "3px", overflow: "hidden" }}>
+                  <div style={{
+                    width: `${Math.min(key.rate_limit_5h, 100)}%`,
+                    height: "100%",
+                    background: barColor(key.rate_limit_5h),
+                    "border-radius": "3px",
+                    transition: "width 300ms ease",
+                  }} />
+                </div>
+                <span style={{ "font-size": "8px", color: barColor(key.rate_limit_5h), width: "28px", "text-align": "right" }}>
+                  {key.rate_limit_5h.toFixed(0)}%
+                </span>
+              </div>
+              {/* 7d bar */}
+              <div style={{ display: "flex", "align-items": "center", gap: "4px" }}>
+                <span style={{ "font-size": "8px", color: "var(--ctp-overlay0)", width: "20px" }}>7d</span>
+                <div style={{ flex: "1", height: "6px", background: "var(--ctp-surface0)", "border-radius": "3px", overflow: "hidden" }}>
+                  <div style={{
+                    width: `${Math.min(key.rate_limit_7d, 100)}%`,
+                    height: "100%",
+                    background: barColor(key.rate_limit_7d),
+                    "border-radius": "3px",
+                    transition: "width 300ms ease",
+                  }} />
+                </div>
+                <span style={{ "font-size": "8px", color: barColor(key.rate_limit_7d), width: "28px", "text-align": "right" }}>
+                  {key.rate_limit_7d.toFixed(0)}%
+                </span>
+              </div>
+            </div>
+          )}
+        </For>
+      </Show>
+    </div>
+  );
+}

--- a/frontend/src/components/network/RequestDetail.tsx
+++ b/frontend/src/components/network/RequestDetail.tsx
@@ -15,7 +15,7 @@ interface RequestDetailProps {
 type Tab = "response" | "request" | "headers";
 
 export type { RequestDetailFull };
-export { tryParseJson, parseSseEvents, extractResponseContent };
+export { tryParseJson, parseSseEvents, extractResponseContent, tryDecodeBase64 };
 
 /** Try to parse JSON and pretty-print it. */
 function tryParseJson(text: string): unknown | null {
@@ -58,6 +58,27 @@ function parseSseEvents(
     });
   }
   return events;
+}
+
+/** Try to decode a base64-encoded string. Returns null if not base64. */
+function tryDecodeBase64(text: string): string | null {
+  const trimmed = text.trim();
+  // Quick heuristic: only attempt if it looks like base64 (long string, no spaces, valid chars)
+  if (trimmed.length < 20 || /\s/.test(trimmed) || !/^[A-Za-z0-9+/=]+$/.test(trimmed)) {
+    return null;
+  }
+  try {
+    const decoded = atob(trimmed);
+    // Check if result is mostly printable ASCII
+    const printable = decoded.split("").filter((c) => {
+      const code = c.charCodeAt(0);
+      return (code >= 32 && code <= 126) || code === 10 || code === 13 || code === 9;
+    }).length;
+    if (printable / decoded.length > 0.8) return decoded;
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 /** Extract text blocks from an API response SSE stream. */
@@ -104,6 +125,40 @@ function extractResponseContent(body: string): {
       }
       const usage = d.usage as Record<string, number>;
       if (usage) outputTokens = usage.output_tokens || 0;
+    }
+
+    // OpenAI/Codex format: choices[].delta.content
+    if (d.choices && Array.isArray(d.choices)) {
+      for (const choice of d.choices as Record<string, unknown>[]) {
+        const delta = choice.delta as Record<string, unknown>;
+        if (delta && typeof delta.content === "string") {
+          text += delta.content;
+        }
+      }
+      if (d.model && typeof d.model === "string") model = d.model;
+      const usage = d.usage as Record<string, number>;
+      if (usage) {
+        inputTokens = usage.prompt_tokens || inputTokens;
+        outputTokens = usage.completion_tokens || outputTokens;
+      }
+    }
+
+    // Gemini format: candidates[].content.parts[].text
+    if (d.candidates && Array.isArray(d.candidates)) {
+      for (const candidate of d.candidates as Record<string, unknown>[]) {
+        const content = candidate.content as Record<string, unknown>;
+        if (content && Array.isArray(content.parts)) {
+          for (const part of content.parts as Record<string, unknown>[]) {
+            if (typeof part.text === "string") text += part.text;
+          }
+        }
+      }
+      const meta = d.usageMetadata as Record<string, number>;
+      if (meta) {
+        inputTokens = meta.promptTokenCount || inputTokens;
+        outputTokens = meta.candidatesTokenCount || outputTokens;
+      }
+      if (d.modelVersion && typeof d.modelVersion === "string") model = d.modelVersion;
     }
   }
 
@@ -264,14 +319,43 @@ export default function RequestDetail(props: RequestDetailProps) {
           <Show
             when={isSse() && responseContent() && !showRawResponse()}
             fallback={
-              <pre style={codeBlockStyle}>
-                {(() => {
-                  const parsed = tryParseJson(props.request.responseBody);
-                  return parsed
-                    ? JSON.stringify(parsed, null, 2)
-                    : props.request.responseBody;
-                })()}
-              </pre>
+              <div>
+                <div style={{ display: "flex", gap: "4px", "margin-bottom": "4px" }}>
+                  <button
+                    data-testid="copy-decoded-btn"
+                    onClick={() => {
+                      const body = props.request.responseBody;
+                      const parsed = tryParseJson(body);
+                      const decoded = parsed ? JSON.stringify(parsed, null, 2) : (tryDecodeBase64(body) || body);
+                      void navigator.clipboard.writeText(decoded);
+                    }}
+                    style={{
+                      padding: "2px 8px",
+                      background: "var(--ctp-surface0)",
+                      border: "1px solid var(--ctp-surface1)",
+                      "border-radius": "3px",
+                      color: "var(--ctp-overlay1)",
+                      "font-size": "10px",
+                      cursor: "pointer",
+                    }}
+                  >
+                    Copy decoded
+                  </button>
+                </div>
+                <pre style={codeBlockStyle}>
+                  {(() => {
+                    const body = props.request.responseBody;
+                    const parsed = tryParseJson(body);
+                    if (parsed) return JSON.stringify(parsed, null, 2);
+                    const b64 = tryDecodeBase64(body);
+                    if (b64) {
+                      const innerParsed = tryParseJson(b64);
+                      return innerParsed ? JSON.stringify(innerParsed, null, 2) : b64;
+                    }
+                    return body;
+                  })()}
+                </pre>
+              </div>
             }
           >
             {/* Structured SSE response view */}

--- a/frontend/src/components/network/RequestRow.tsx
+++ b/frontend/src/components/network/RequestRow.tsx
@@ -11,6 +11,7 @@ interface ApiRequest {
   timestamp: number;
   requestPreview?: string;
   responsePreview?: string;
+  category?: string;
 }
 
 interface RequestRowProps {
@@ -53,6 +54,18 @@ function formatTime(timestamp: number): string {
   return `${h}:${m}:${s}`;
 }
 
+/** Map traffic category to Catppuccin Mocha color */
+function categoryColor(category?: string): string {
+  switch (category) {
+    case "Api": return "#89b4fa"; // ctp-blue
+    case "Telemetry": return "#f9e2af"; // ctp-yellow
+    case "Auth": return "#cba6f7"; // ctp-mauve
+    case "Update": return "#fab387"; // ctp-peach
+    case "Git": return "#a6e3a1"; // ctp-green
+    default: return "#6c7086"; // ctp-overlay0
+  }
+}
+
 function shortUrl(url: string): string {
   try {
     const u = new URL(url);
@@ -65,7 +78,7 @@ function shortUrl(url: string): string {
 }
 
 export type { ApiRequest };
-export { statusColor, statusColorDark, formatSize, formatTime, shortUrl };
+export { statusColor, statusColorDark, formatSize, formatTime, shortUrl, categoryColor };
 
 export default function RequestRow(props: RequestRowProps) {
   const [hovered, setHovered] = createSignal(false);
@@ -116,17 +129,28 @@ export default function RequestRow(props: RequestRowProps) {
         transition: "background 150ms ease",
       }}
     >
-      {/* Primary row: method, url, status, size, time, waterfall */}
+      {/* Primary row: category dot, method, url, status, size, time, waterfall */}
       <div
         style={{
           display: "grid",
-          "grid-template-columns": "60px 58px 1fr 50px 60px 60px 160px",
+          "grid-template-columns": "12px 60px 58px 1fr 50px 60px 60px 160px",
           gap: "8px",
           "align-items": "center",
           padding: "6px 12px 2px 12px",
           "font-size": "12px",
         }}
       >
+        {/* Category dot */}
+        <span
+          title={props.request.category || "Unknown"}
+          style={{
+            width: "8px",
+            height: "8px",
+            "border-radius": "50%",
+            background: categoryColor(props.request.category),
+            "flex-shrink": "0",
+          }}
+        />
         <span style={{ "font-weight": "600", color: "var(--ctp-blue)" }}>
           {props.request.method}
         </span>

--- a/frontend/src/components/network/RequestRow.tsx
+++ b/frontend/src/components/network/RequestRow.tsx
@@ -1,4 +1,4 @@
-import { createSignal, Show } from "solid-js";
+import { createSignal, Show, onCleanup } from "solid-js";
 
 interface ApiRequest {
   id: string;
@@ -22,6 +22,10 @@ interface RequestRowProps {
   timelineStart: number;
   /** Total timeline duration (ms) */
   timelineDuration: number;
+  /** Called when user selects "Block this domain" from context menu */
+  onQuickBlock?: (domain: string) => void;
+  /** Called when user selects "Block all [category]" from context menu */
+  onBlockCategory?: (category: string) => void;
 }
 
 function statusColor(code: number): string {
@@ -82,6 +86,27 @@ export { statusColor, statusColorDark, formatSize, formatTime, shortUrl, categor
 
 export default function RequestRow(props: RequestRowProps) {
   const [hovered, setHovered] = createSignal(false);
+  const [contextMenu, setContextMenu] = createSignal<{ x: number; y: number } | null>(null);
+
+  function getDomain(): string {
+    try {
+      return new URL(props.request.url).hostname;
+    } catch {
+      return props.request.url;
+    }
+  }
+
+  function handleContextMenu(e: MouseEvent) {
+    e.preventDefault();
+    setContextMenu({ x: e.clientX, y: e.clientY });
+
+    const dismiss = () => {
+      setContextMenu(null);
+      document.removeEventListener("click", dismiss);
+    };
+    document.addEventListener("click", dismiss);
+    onCleanup(() => document.removeEventListener("click", dismiss));
+  }
 
   const barOffset = () => {
     if (props.timelineDuration <= 0) return 0;
@@ -108,6 +133,7 @@ export default function RequestRow(props: RequestRowProps) {
     <button
       data-testid={`request-row-${props.request.id}`}
       onClick={() => props.onClick()}
+      onContextMenu={handleContextMenu}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{
@@ -299,6 +325,70 @@ export default function RequestRow(props: RequestRowProps) {
               </span>
               {props.request.responsePreview}
             </span>
+          </Show>
+        </div>
+      </Show>
+
+      {/* Context Menu */}
+      <Show when={contextMenu()}>
+        <div
+          data-testid="request-context-menu"
+          style={{
+            position: "fixed",
+            left: `${contextMenu()!.x}px`,
+            top: `${contextMenu()!.y}px`,
+            "z-index": "1000",
+            background: "var(--ctp-surface0)",
+            border: "1px solid var(--ctp-surface1)",
+            "border-radius": "6px",
+            "box-shadow": "0 4px 12px rgba(0,0,0,0.4)",
+            padding: "4px 0",
+            "min-width": "180px",
+          }}
+        >
+          <Show when={props.onQuickBlock}>
+            <button
+              data-testid="ctx-block-domain"
+              onClick={() => {
+                props.onQuickBlock?.(getDomain());
+                setContextMenu(null);
+              }}
+              style={{
+                display: "block",
+                width: "100%",
+                padding: "6px 12px",
+                "font-size": "11px",
+                background: "transparent",
+                border: "none",
+                color: "var(--ctp-red)",
+                cursor: "pointer",
+                "text-align": "left",
+              }}
+            >
+              Block {getDomain()}
+            </button>
+          </Show>
+          <Show when={props.onBlockCategory && props.request.category}>
+            <button
+              data-testid="ctx-block-category"
+              onClick={() => {
+                props.onBlockCategory?.(props.request.category!);
+                setContextMenu(null);
+              }}
+              style={{
+                display: "block",
+                width: "100%",
+                padding: "6px 12px",
+                "font-size": "11px",
+                background: "transparent",
+                border: "none",
+                color: "var(--ctp-yellow)",
+                cursor: "pointer",
+                "text-align": "left",
+              }}
+            >
+              Block all {props.request.category}
+            </button>
           </Show>
         </div>
       </Show>

--- a/frontend/src/components/network/RewritePanel.tsx
+++ b/frontend/src/components/network/RewritePanel.tsx
@@ -1,0 +1,173 @@
+import { createSignal, Show, onMount } from "solid-js";
+import { useSession } from "../../App";
+
+export default function RewritePanel() {
+  const store = useSession();
+  const [modelOverride, setModelOverride] = createSignal("");
+  const [temperature, setTemperature] = createSignal<number | null>(null);
+  const [maxTokens, setMaxTokens] = createSignal<number | null>(null);
+  const [thinkingType, setThinkingType] = createSignal("");
+  const [pureMode, setPureMode] = createSignal(false);
+
+  async function fetchConfig() {
+    const base = store.state.httpApiUrl;
+    const sid = store.state.activeSessionId;
+    if (!base || !sid) return;
+    try {
+      const res = await fetch(`${base}/api/proxy/rewrite/${sid}`);
+      if (res.ok) {
+        const data = await res.json();
+        setModelOverride(data.model_override || "");
+        setTemperature(data.temperature ?? null);
+        setMaxTokens(data.max_tokens ?? null);
+        setThinkingType(data.thinking_type || "");
+        setPureMode(data.pure_mode || false);
+      }
+    } catch { /* ignore */ }
+  }
+
+  async function saveConfig() {
+    const base = store.state.httpApiUrl;
+    const sid = store.state.activeSessionId;
+    if (!base || !sid) return;
+    try {
+      await fetch(`${base}/api/proxy/rewrite/${sid}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model_override: modelOverride() || null,
+          temperature: temperature(),
+          max_tokens: maxTokens(),
+          thinking_type: thinkingType() || null,
+          pure_mode: pureMode(),
+        }),
+      });
+    } catch { /* ignore */ }
+  }
+
+  onMount(() => {
+    void fetchConfig();
+  });
+
+  const inputStyle = {
+    padding: "3px 6px",
+    "font-size": "10px",
+    background: "var(--ctp-surface0)",
+    border: "1px solid var(--ctp-surface1)",
+    "border-radius": "3px",
+    color: "var(--ctp-text)",
+    outline: "none",
+  };
+
+  return (
+    <div
+      data-testid="rewrite-panel"
+      style={{
+        padding: "8px 12px",
+        "border-top": "1px solid var(--ctp-surface0)",
+        background: "var(--ctp-mantle)",
+      }}
+    >
+      <div
+        style={{
+          "font-size": "11px",
+          "font-weight": "600",
+          color: "var(--ctp-text)",
+          "margin-bottom": "6px",
+        }}
+      >
+        Request Rewrite
+      </div>
+
+      <div style={{ display: "flex", gap: "8px", "flex-wrap": "wrap", "align-items": "center" }}>
+        {/* Model Override */}
+        <label style={{ "font-size": "10px", color: "var(--ctp-subtext0)" }}>
+          Model:
+          <select
+            data-testid="rewrite-model"
+            value={modelOverride()}
+            onChange={(e) => { setModelOverride(e.currentTarget.value); void saveConfig(); }}
+            style={inputStyle}
+          >
+            <option value="">Default</option>
+            <option value="claude-opus-4-6">Opus 4.6</option>
+            <option value="claude-sonnet-4-6">Sonnet 4.6</option>
+            <option value="claude-haiku-4-5-20251001">Haiku 4.5</option>
+          </select>
+        </label>
+
+        {/* Temperature */}
+        <label style={{ "font-size": "10px", color: "var(--ctp-subtext0)" }}>
+          Temp:
+          <input
+            type="number"
+            min="0"
+            max="2"
+            step="0.1"
+            value={temperature() ?? ""}
+            onInput={(e) => {
+              const v = e.currentTarget.value;
+              setTemperature(v ? parseFloat(v) : null);
+            }}
+            onBlur={() => void saveConfig()}
+            style={{ ...inputStyle, width: "50px" }}
+          />
+        </label>
+
+        {/* Max Tokens */}
+        <label style={{ "font-size": "10px", color: "var(--ctp-subtext0)" }}>
+          Max:
+          <input
+            type="number"
+            min="1"
+            step="1024"
+            value={maxTokens() ?? ""}
+            onInput={(e) => {
+              const v = e.currentTarget.value;
+              setMaxTokens(v ? parseInt(v, 10) : null);
+            }}
+            onBlur={() => void saveConfig()}
+            style={{ ...inputStyle, width: "70px" }}
+          />
+        </label>
+
+        {/* Thinking Type */}
+        <Show when={modelOverride().includes("opus") || modelOverride().includes("sonnet") || !modelOverride()}>
+          <label style={{ "font-size": "10px", color: "var(--ctp-subtext0)" }}>
+            Think:
+            <select
+              value={thinkingType()}
+              onChange={(e) => { setThinkingType(e.currentTarget.value); void saveConfig(); }}
+              style={inputStyle}
+            >
+              <option value="">Default</option>
+              <option value="enabled">Enabled</option>
+              <option value="disabled">Disabled</option>
+            </select>
+          </label>
+        </Show>
+
+        {/* Pure Mode */}
+        <label
+          style={{
+            display: "flex",
+            "align-items": "center",
+            gap: "3px",
+            "font-size": "10px",
+            color: pureMode() ? "var(--ctp-green)" : "var(--ctp-overlay0)",
+            cursor: "pointer",
+          }}
+        >
+          <input
+            data-testid="rewrite-pure"
+            type="checkbox"
+            checked={pureMode()}
+            onChange={() => { setPureMode(!pureMode()); void saveConfig(); }}
+            style={{ width: "12px", height: "12px" }}
+          />
+          Pure
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/network/RuleEditor.tsx
+++ b/frontend/src/components/network/RuleEditor.tsx
@@ -1,0 +1,259 @@
+import { createSignal, For, Show, onMount, onCleanup } from "solid-js";
+import { useSession } from "../../App";
+
+interface NetworkRule {
+  id: string;
+  domain_pattern?: string;
+  category_filter?: string;
+  action: "allow" | "block" | { delay: { ms: number } };
+  priority: number;
+}
+
+export default function RuleEditor() {
+  const store = useSession();
+  const [rules, setRules] = createSignal<NetworkRule[]>([]);
+  const [newDomain, setNewDomain] = createSignal("");
+  const [newCategory, setNewCategory] = createSignal("");
+  const [newAction, setNewAction] = createSignal<"allow" | "block">("block");
+  const [newPriority, _setNewPriority] = createSignal(50);
+
+  async function fetchRules() {
+    const base = store.state.httpApiUrl;
+    const sid = store.state.activeSessionId;
+    if (!base || !sid) return;
+    try {
+      const res = await fetch(`${base}/api/proxy/network-rules/${sid}`);
+      if (res.ok) {
+        const data = await res.json();
+        setRules(data.rules || []);
+      }
+    } catch { /* ignore */ }
+  }
+
+  async function addRule() {
+    const base = store.state.httpApiUrl;
+    const sid = store.state.activeSessionId;
+    if (!base || !sid) return;
+    const body: Record<string, unknown> = {
+      session_id: sid,
+      action: newAction(),
+      priority: newPriority(),
+    };
+    if (newDomain()) body.domain_pattern = newDomain();
+    if (newCategory()) body.category_filter = newCategory();
+
+    try {
+      await fetch(`${base}/api/proxy/network-rules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      setNewDomain("");
+      setNewCategory("");
+      await fetchRules();
+    } catch { /* ignore */ }
+  }
+
+  async function deleteRule(ruleId: string) {
+    const base = store.state.httpApiUrl;
+    const sid = store.state.activeSessionId;
+    if (!base || !sid) return;
+    try {
+      await fetch(`${base}/api/proxy/network-rules/${sid}/${ruleId}`, {
+        method: "DELETE",
+      });
+      await fetchRules();
+    } catch { /* ignore */ }
+  }
+
+  onMount(() => {
+    fetchRules();
+    const interval = setInterval(fetchRules, 5000);
+    onCleanup(() => clearInterval(interval));
+  });
+
+  return (
+    <div
+      data-testid="rule-editor"
+      style={{
+        padding: "8px 12px",
+        "border-top": "1px solid var(--ctp-surface0)",
+        background: "var(--ctp-mantle)",
+        "max-height": "250px",
+        overflow: "auto",
+      }}
+    >
+      <div
+        style={{
+          "font-size": "11px",
+          "font-weight": "600",
+          color: "var(--ctp-text)",
+          "margin-bottom": "6px",
+        }}
+      >
+        Network Rules
+      </div>
+
+      {/* Existing rules list */}
+      <Show
+        when={rules().length > 0}
+        fallback={
+          <div
+            style={{
+              "font-size": "10px",
+              color: "var(--ctp-overlay0)",
+              "margin-bottom": "8px",
+            }}
+          >
+            No rules configured
+          </div>
+        }
+      >
+        <div style={{ "margin-bottom": "8px" }}>
+          <For each={rules()}>
+            {(rule) => (
+              <div
+                style={{
+                  display: "flex",
+                  "align-items": "center",
+                  gap: "6px",
+                  padding: "3px 0",
+                  "font-size": "11px",
+                  "border-bottom": "1px solid var(--ctp-surface0)",
+                }}
+              >
+                <span
+                  style={{
+                    padding: "1px 6px",
+                    "border-radius": "3px",
+                    "font-size": "9px",
+                    "font-weight": "600",
+                    background:
+                      rule.action === "block"
+                        ? "var(--ctp-red)"
+                        : rule.action === "allow"
+                          ? "var(--ctp-green)"
+                          : "var(--ctp-yellow)",
+                    color: "var(--ctp-base)",
+                  }}
+                >
+                  {typeof rule.action === "string"
+                    ? rule.action.toUpperCase()
+                    : `DELAY ${rule.action.delay.ms}ms`}
+                </span>
+                <span style={{ color: "var(--ctp-text)", flex: "1" }}>
+                  {rule.domain_pattern || rule.category_filter || "any"}
+                </span>
+                <span
+                  style={{
+                    "font-size": "9px",
+                    color: "var(--ctp-overlay0)",
+                  }}
+                >
+                  p{rule.priority}
+                </span>
+                <button
+                  onClick={() => deleteRule(rule.id)}
+                  style={{
+                    padding: "1px 4px",
+                    "font-size": "9px",
+                    background: "transparent",
+                    border: "1px solid var(--ctp-surface1)",
+                    "border-radius": "3px",
+                    color: "var(--ctp-red)",
+                    cursor: "pointer",
+                  }}
+                >
+                  x
+                </button>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+
+      {/* Add rule form */}
+      <div
+        style={{
+          display: "flex",
+          gap: "4px",
+          "align-items": "center",
+          "flex-wrap": "wrap",
+        }}
+      >
+        <input
+          data-testid="rule-domain-input"
+          type="text"
+          placeholder="*.domain.com"
+          value={newDomain()}
+          onInput={(e) => setNewDomain(e.currentTarget.value)}
+          style={{
+            flex: "1",
+            "min-width": "120px",
+            padding: "3px 6px",
+            "font-size": "10px",
+            background: "var(--ctp-surface0)",
+            border: "1px solid var(--ctp-surface1)",
+            "border-radius": "3px",
+            color: "var(--ctp-text)",
+            outline: "none",
+          }}
+        />
+        <select
+          data-testid="rule-category-select"
+          value={newCategory()}
+          onChange={(e) => setNewCategory(e.currentTarget.value)}
+          style={{
+            padding: "3px 6px",
+            "font-size": "10px",
+            background: "var(--ctp-surface0)",
+            border: "1px solid var(--ctp-surface1)",
+            "border-radius": "3px",
+            color: "var(--ctp-text)",
+          }}
+        >
+          <option value="">Any Category</option>
+          <option value="Api">Api</option>
+          <option value="Telemetry">Telemetry</option>
+          <option value="Auth">Auth</option>
+          <option value="Update">Update</option>
+          <option value="Git">Git</option>
+        </select>
+        <select
+          data-testid="rule-action-select"
+          value={newAction()}
+          onChange={(e) =>
+            setNewAction(e.currentTarget.value as "allow" | "block")
+          }
+          style={{
+            padding: "3px 6px",
+            "font-size": "10px",
+            background: "var(--ctp-surface0)",
+            border: "1px solid var(--ctp-surface1)",
+            "border-radius": "3px",
+            color: "var(--ctp-text)",
+          }}
+        >
+          <option value="block">Block</option>
+          <option value="allow">Allow</option>
+        </select>
+        <button
+          data-testid="rule-add-btn"
+          onClick={addRule}
+          style={{
+            padding: "3px 8px",
+            "font-size": "10px",
+            "font-weight": "600",
+            background: "var(--ctp-blue)",
+            border: "none",
+            "border-radius": "3px",
+            color: "var(--ctp-base)",
+            cursor: "pointer",
+          }}
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -53,6 +53,7 @@ time.workspace = true
 dashmap.workspace = true
 tokio-rustls.workspace = true
 rustls-native-certs.workspace = true
+ring.workspace = true
 togaf-parser = { path = "../crates/togaf-parser" }
 
 [dev-dependencies]

--- a/server/src/db/queries.rs
+++ b/server/src/db/queries.rs
@@ -334,7 +334,7 @@ impl Db {
     pub async fn insert_api_request(&self, r: &ApiRequestComponent) -> DbResult<()> {
         self.conn
             .execute(
-                "INSERT INTO api_requests (id, session_id, method, url, request_body, response_body, status_code, latency_ms, timestamp, request_headers, response_headers, request_size, response_size, category) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+                "INSERT INTO api_requests (id, session_id, method, url, request_body, response_body, status_code, latency_ms, timestamp, request_headers, response_headers, request_size, response_size, traffic_category) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
                 limbo::params!(
                     r.id.to_string(),
                     r.session_id.to_string(),
@@ -349,7 +349,7 @@ impl Db {
                     option_to_value(&r.response_headers),
                     option_u64_to_value(r.request_size),
                     option_u64_to_value(r.response_size),
-                    option_to_value(&r.category)
+                    option_to_value(&r.traffic_category)
                 ),
             )
             .await?;
@@ -363,7 +363,7 @@ impl Db {
         let mut rows = self
             .conn
             .query(
-                "SELECT id, session_id, method, url, request_body, response_body, status_code, latency_ms, timestamp, request_headers, response_headers, request_size, response_size, category FROM api_requests WHERE session_id = ?1 ORDER BY timestamp",
+                "SELECT id, session_id, method, url, request_body, response_body, status_code, latency_ms, timestamp, request_headers, response_headers, request_size, response_size, traffic_category FROM api_requests WHERE session_id = ?1 ORDER BY timestamp",
                 limbo::params!(session_id.to_string()),
             )
             .await?;
@@ -380,7 +380,7 @@ impl Db {
         let mut rows = self
             .conn
             .query(
-                "SELECT id, session_id, method, url, request_body, response_body, status_code, latency_ms, timestamp, request_headers, response_headers, request_size, response_size, category FROM api_requests ORDER BY timestamp",
+                "SELECT id, session_id, method, url, request_body, response_body, status_code, latency_ms, timestamp, request_headers, response_headers, request_size, response_size, traffic_category FROM api_requests ORDER BY timestamp",
                 (),
             )
             .await?;
@@ -580,7 +580,7 @@ fn row_to_api_request(row: &limbo::Row) -> DbResult<ApiRequestComponent> {
         response_size: optional_int(&row.get_value(12)?).map(|v| v as u64),
         // category column may not exist in older databases (added in CONNECT MITM phase).
         // Gracefully default to None if column is missing.
-        category: row.get_value(13).ok().and_then(|v| optional_text(&v)),
+        traffic_category: row.get_value(13).ok().and_then(|v| optional_text(&v)),
     })
 }
 

--- a/server/src/db/schema.rs
+++ b/server/src/db/schema.rs
@@ -68,7 +68,7 @@ CREATE TABLE IF NOT EXISTS api_requests (
     response_headers TEXT,
     request_size INTEGER,
     response_size INTEGER,
-    category TEXT
+    traffic_category TEXT
 )";
 
 // Standalone FTS5 table (no content= since Limbo lacks triggers)
@@ -155,6 +155,10 @@ pub async fn migrate(conn: &Connection) -> Result<bool, limbo::Error> {
             Err(e) => return Err(e),
         }
     }
+
+    // No additional column migrations needed — new DBs include `category` in CREATE TABLE.
+    // If an old DB is missing the column, the proxy requests SELECT will fail gracefully
+    // (row_to_api_request uses .ok() for column 13) and old data won't have categories.
 
     // FTS5 is optional — Limbo may not support it in all versions
     let fts5_available = match conn.execute(CREATE_MESSAGES_FTS, ()).await {

--- a/server/src/ecs/components.rs
+++ b/server/src/ecs/components.rs
@@ -161,5 +161,5 @@ pub struct ApiRequestComponent {
     pub request_size: Option<u64>,
     pub response_size: Option<u64>,
     /// Traffic category for CONNECT MITM requests (e.g. "telemetry", "auth").
-    pub category: Option<String>,
+    pub traffic_category: Option<String>,
 }

--- a/server/src/ecs/world.rs
+++ b/server/src/ecs/world.rs
@@ -699,7 +699,7 @@ mod tests {
             response_headers: None,
             request_size: None,
             response_size: None,
-            category: None,
+            traffic_category: None,
         });
 
         assert_eq!(world.query_files_by_session(sid).len(), 1);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -298,6 +298,10 @@ async fn main() -> anyhow::Result<()> {
             "/api/proxy/inject/{session_id}",
             get(api_get_inject_config).put(api_set_inject_config),
         )
+        .route(
+            "/api/proxy/rewrite/{session_id}",
+            get(api_get_rewrite_config).put(api_set_rewrite_config),
+        )
         .route("/api/plans", get(api_list_plans))
         .route(
             "/api/plans/for-session/{session_id}",
@@ -3659,6 +3663,24 @@ async fn api_set_inject_config(
     axum::Json(config): axum::Json<noaide_server::proxy::inject::InjectConfig>,
 ) -> axum::Json<serde_json::Value> {
     state.proxy.inject_store.set(session_id, config);
+    axum::Json(serde_json::json!({ "ok": true }))
+}
+
+// ── Rewrite Config Endpoints ────────────────────────────────────────────────
+
+async fn api_get_rewrite_config(
+    State(state): State<AppState>,
+    axum::extract::Path(session_id): axum::extract::Path<String>,
+) -> axum::Json<noaide_server::proxy::rewrite::RewriteConfig> {
+    axum::Json(state.proxy.rewrite_store.get(&session_id))
+}
+
+async fn api_set_rewrite_config(
+    State(state): State<AppState>,
+    axum::extract::Path(session_id): axum::extract::Path<String>,
+    axum::Json(config): axum::Json<noaide_server::proxy::rewrite::RewriteConfig>,
+) -> axum::Json<serde_json::Value> {
+    state.proxy.rewrite_store.set(session_id, config);
     axum::Json(serde_json::json!({ "ok": true }))
 }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -307,10 +307,7 @@ async fn main() -> anyhow::Result<()> {
             get(api_get_proxy_config).put(api_set_proxy_config),
         )
         .route("/api/proxy/presets", get(api_list_presets))
-        .route(
-            "/api/proxy/keys",
-            get(api_list_keys).post(api_add_key),
-        )
+        .route("/api/proxy/keys", get(api_list_keys).post(api_add_key))
         .route("/api/proxy/keys/{key_id}", delete(api_delete_key))
         .route("/api/proxy/keys/status", get(api_keys_status))
         .route("/api/proxy/audit", get(api_get_audit))
@@ -3699,10 +3696,7 @@ async fn api_set_proxy_config(
     axum::extract::Path(session_id): axum::extract::Path<String>,
     axum::Json(config): axum::Json<noaide_server::proxy::persist::ProxyConfig>,
 ) -> axum::Json<serde_json::Value> {
-    state
-        .proxy
-        .proxy_modes
-        .set(session_id.clone(), config.mode);
+    state.proxy.proxy_modes.set(session_id.clone(), config.mode);
     state
         .proxy
         .inject_store
@@ -3796,9 +3790,7 @@ struct AddKeyRequest {
     label: String,
 }
 
-async fn api_list_keys(
-    State(state): State<AppState>,
-) -> axum::Json<serde_json::Value> {
+async fn api_list_keys(State(state): State<AppState>) -> axum::Json<serde_json::Value> {
     let keys: Vec<serde_json::Value> = state
         .proxy
         .key_store
@@ -3824,7 +3816,10 @@ async fn api_add_key(
     State(state): State<AppState>,
     axum::Json(body): axum::Json<AddKeyRequest>,
 ) -> (StatusCode, axum::Json<serde_json::Value>) {
-    let id = state.proxy.key_store.add_key(&body.provider, &body.key, &body.label);
+    let id = state
+        .proxy
+        .key_store
+        .add_key(&body.provider, &body.key, &body.label);
     (
         StatusCode::CREATED,
         axum::Json(serde_json::json!({ "id": id })),
@@ -3839,9 +3834,7 @@ async fn api_delete_key(
     axum::Json(serde_json::json!({ "removed": removed }))
 }
 
-async fn api_keys_status(
-    State(state): State<AppState>,
-) -> axum::Json<serde_json::Value> {
+async fn api_keys_status(State(state): State<AppState>) -> axum::Json<serde_json::Value> {
     axum::Json(serde_json::json!({ "keys": state.proxy.key_store.status() }))
 }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -313,6 +313,8 @@ async fn main() -> anyhow::Result<()> {
         )
         .route("/api/proxy/keys/{key_id}", delete(api_delete_key))
         .route("/api/proxy/keys/status", get(api_keys_status))
+        .route("/api/proxy/audit", get(api_get_audit))
+        .route("/api/proxy/audit/export", get(api_export_audit))
         .route("/api/plans", get(api_list_plans))
         .route(
             "/api/plans/for-session/{session_id}",
@@ -3734,6 +3736,55 @@ async fn api_list_presets() -> axum::Json<serde_json::Value> {
     })
     .collect();
     axum::Json(serde_json::json!({ "presets": presets }))
+}
+
+// ── Audit Log Endpoints ─────────────────────────────────────────────────────
+
+#[derive(serde::Deserialize)]
+struct AuditQuery {
+    session_id: Option<String>,
+    model: Option<String>,
+    limit: Option<usize>,
+    format: Option<String>,
+}
+
+async fn api_get_audit(
+    axum::extract::Query(query): axum::extract::Query<AuditQuery>,
+) -> axum::Json<serde_json::Value> {
+    let entries = noaide_server::proxy::audit::query_entries(
+        query.session_id.as_deref(),
+        query.model.as_deref(),
+        query.limit.unwrap_or(100),
+    );
+    axum::Json(serde_json::json!({ "entries": entries }))
+}
+
+async fn api_export_audit(
+    axum::extract::Query(query): axum::extract::Query<AuditQuery>,
+) -> axum::response::Response {
+    let entries = noaide_server::proxy::audit::query_entries(
+        query.session_id.as_deref(),
+        query.model.as_deref(),
+        query.limit.unwrap_or(10000),
+    );
+
+    if query.format.as_deref() == Some("csv") {
+        let csv = noaide_server::proxy::audit::export_csv(&entries);
+        axum::response::Response::builder()
+            .header("content-type", "text/csv")
+            .header(
+                "content-disposition",
+                "attachment; filename=\"noaide-audit.csv\"",
+            )
+            .body(axum::body::Body::from(csv))
+            .unwrap()
+    } else {
+        let json = serde_json::to_string_pretty(&entries).unwrap_or_default();
+        axum::response::Response::builder()
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(json))
+            .unwrap()
+    }
 }
 
 // ── API Key Endpoints ───────────────────────────────────────────────────────

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -290,6 +290,10 @@ async fn main() -> anyhow::Result<()> {
             "/api/proxy/network-rules/{session_id}/quick-block",
             post(api_quick_block_domain),
         )
+        .route(
+            "/api/proxy/mode/{session_id}",
+            get(api_get_proxy_mode).put(api_set_proxy_mode),
+        )
         .route("/api/plans", get(api_list_plans))
         .route(
             "/api/plans/for-session/{session_id}",
@@ -3610,6 +3614,30 @@ async fn api_quick_block_domain(
         StatusCode::CREATED,
         axum::Json(serde_json::json!({ "id": id })),
     )
+}
+
+// ── Proxy Mode Endpoints ────────────────────────────────────────────────────
+
+async fn api_get_proxy_mode(
+    State(state): State<AppState>,
+    axum::extract::Path(session_id): axum::extract::Path<String>,
+) -> axum::Json<serde_json::Value> {
+    let mode = state.proxy.proxy_modes.get(&session_id);
+    axum::Json(serde_json::json!({ "mode": mode }))
+}
+
+#[derive(serde::Deserialize)]
+struct SetModeRequest {
+    mode: noaide_server::proxy::modes::ProxyMode,
+}
+
+async fn api_set_proxy_mode(
+    State(state): State<AppState>,
+    axum::extract::Path(session_id): axum::extract::Path<String>,
+    axum::Json(body): axum::Json<SetModeRequest>,
+) -> axum::Json<serde_json::Value> {
+    state.proxy.proxy_modes.set(session_id, body.mode);
+    axum::Json(serde_json::json!({ "ok": true }))
 }
 
 // ── Git API Endpoints ────────────────────────────────────────────────────────

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -307,6 +307,12 @@ async fn main() -> anyhow::Result<()> {
             get(api_get_proxy_config).put(api_set_proxy_config),
         )
         .route("/api/proxy/presets", get(api_list_presets))
+        .route(
+            "/api/proxy/keys",
+            get(api_list_keys).post(api_add_key),
+        )
+        .route("/api/proxy/keys/{key_id}", delete(api_delete_key))
+        .route("/api/proxy/keys/status", get(api_keys_status))
         .route("/api/plans", get(api_list_plans))
         .route(
             "/api/plans/for-session/{session_id}",
@@ -3728,6 +3734,64 @@ async fn api_list_presets() -> axum::Json<serde_json::Value> {
     })
     .collect();
     axum::Json(serde_json::json!({ "presets": presets }))
+}
+
+// ── API Key Endpoints ───────────────────────────────────────────────────────
+
+#[derive(serde::Deserialize)]
+struct AddKeyRequest {
+    provider: String,
+    key: String,
+    label: String,
+}
+
+async fn api_list_keys(
+    State(state): State<AppState>,
+) -> axum::Json<serde_json::Value> {
+    let keys: Vec<serde_json::Value> = state
+        .proxy
+        .key_store
+        .list_keys()
+        .into_iter()
+        .map(|k| {
+            serde_json::json!({
+                "id": k.id,
+                "provider": k.provider,
+                "label": k.label,
+                "active": k.active,
+                "rate_limit_5h": k.rate_limit_5h,
+                "rate_limit_7d": k.rate_limit_7d,
+                "last_used": k.last_used,
+                "request_count": k.request_count,
+            })
+        })
+        .collect();
+    axum::Json(serde_json::json!({ "keys": keys }))
+}
+
+async fn api_add_key(
+    State(state): State<AppState>,
+    axum::Json(body): axum::Json<AddKeyRequest>,
+) -> (StatusCode, axum::Json<serde_json::Value>) {
+    let id = state.proxy.key_store.add_key(&body.provider, &body.key, &body.label);
+    (
+        StatusCode::CREATED,
+        axum::Json(serde_json::json!({ "id": id })),
+    )
+}
+
+async fn api_delete_key(
+    State(state): State<AppState>,
+    axum::extract::Path(key_id): axum::extract::Path<String>,
+) -> axum::Json<serde_json::Value> {
+    let removed = state.proxy.key_store.remove_key(&key_id);
+    axum::Json(serde_json::json!({ "removed": removed }))
+}
+
+async fn api_keys_status(
+    State(state): State<AppState>,
+) -> axum::Json<serde_json::Value> {
+    axum::Json(serde_json::json!({ "keys": state.proxy.key_store.status() }))
 }
 
 // ── Rewrite Config Endpoints ────────────────────────────────────────────────

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -3589,10 +3589,17 @@ async fn api_quick_block_domain(
     axum::extract::Path(session_id): axum::extract::Path<String>,
     axum::Json(body): axum::Json<QuickBlockRequest>,
 ) -> (StatusCode, axum::Json<serde_json::Value>) {
+    // Auto-glob: "datadoghq.com" → "*.datadoghq.com" so subdomains are also blocked.
+    // If user already specified a glob pattern, keep it as-is.
+    let pattern = if body.domain.starts_with("*.") {
+        body.domain
+    } else {
+        format!("*.{}", body.domain)
+    };
     let rule = noaide_server::proxy::NetworkRule {
         id: String::new(),
         session_id: session_id.clone(),
-        domain_pattern: Some(body.domain),
+        domain_pattern: Some(pattern),
         category_filter: None,
         action: noaide_server::proxy::RuleAction::Block,
         enabled: true,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2692,7 +2692,7 @@ fn proxy_log_to_component(log: &noaide_server::proxy::ApiRequestLog) -> ApiReque
         response_headers: Some(serde_json::to_string(&log.response_headers).unwrap_or_default()),
         request_size: Some(log.request_size as u64),
         response_size: Some(log.response_size as u64),
-        category: log.category.clone(),
+        traffic_category: log.category.clone(),
     }
 }
 
@@ -2724,7 +2724,7 @@ fn component_to_proxy_log(c: &ApiRequestComponent) -> noaide_server::proxy::ApiR
         timestamp: c.timestamp,
         request_size: c.request_size.unwrap_or(0) as usize,
         response_size: c.response_size.unwrap_or(0) as usize,
-        category: c.category.clone(),
+        category: c.traffic_category.clone(),
     }
 }
 
@@ -2764,6 +2764,7 @@ async fn api_get_proxy_requests(
                 "timestamp": r.timestamp,
                 "requestPreview": req_preview,
                 "responsePreview": res_preview,
+                "category": r.category,
             })
         })
         .collect();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -302,6 +302,11 @@ async fn main() -> anyhow::Result<()> {
             "/api/proxy/rewrite/{session_id}",
             get(api_get_rewrite_config).put(api_set_rewrite_config),
         )
+        .route(
+            "/api/proxy/config/{session_id}",
+            get(api_get_proxy_config).put(api_set_proxy_config),
+        )
+        .route("/api/proxy/presets", get(api_list_presets))
         .route("/api/plans", get(api_list_plans))
         .route(
             "/api/plans/for-session/{session_id}",
@@ -3664,6 +3669,65 @@ async fn api_set_inject_config(
 ) -> axum::Json<serde_json::Value> {
     state.proxy.inject_store.set(session_id, config);
     axum::Json(serde_json::json!({ "ok": true }))
+}
+
+// ── Proxy Config Endpoints (combined persistence) ──────────────────────────
+
+async fn api_get_proxy_config(
+    State(state): State<AppState>,
+    axum::extract::Path(session_id): axum::extract::Path<String>,
+) -> axum::Json<noaide_server::proxy::persist::ProxyConfig> {
+    // Build config from current in-memory state
+    let config = noaide_server::proxy::persist::ProxyConfig {
+        mode: state.proxy.proxy_modes.get(&session_id),
+        inject: state.proxy.inject_store.get(&session_id),
+        rewrite: state.proxy.rewrite_store.get(&session_id),
+    };
+    axum::Json(config)
+}
+
+async fn api_set_proxy_config(
+    State(state): State<AppState>,
+    axum::extract::Path(session_id): axum::extract::Path<String>,
+    axum::Json(config): axum::Json<noaide_server::proxy::persist::ProxyConfig>,
+) -> axum::Json<serde_json::Value> {
+    state
+        .proxy
+        .proxy_modes
+        .set(session_id.clone(), config.mode);
+    state
+        .proxy
+        .inject_store
+        .set(session_id.clone(), config.inject.clone());
+    state
+        .proxy
+        .rewrite_store
+        .set(session_id.clone(), config.rewrite.clone());
+    // Persist to disk (debounced)
+    noaide_server::proxy::persist::schedule_save(session_id, config);
+    axum::Json(serde_json::json!({ "ok": true }))
+}
+
+async fn api_list_presets() -> axum::Json<serde_json::Value> {
+    use noaide_server::proxy::inject::Preset;
+    let presets: Vec<serde_json::Value> = [
+        Preset::NoaideContext,
+        Preset::AntiLaziness,
+        Preset::VerifyEvidence,
+        Preset::Speed,
+        Preset::Verbose,
+        Preset::GermanOnly,
+    ]
+    .iter()
+    .map(|p| {
+        serde_json::json!({
+            "id": p,
+            "label": p.label(),
+            "text": p.text(),
+        })
+    })
+    .collect();
+    axum::Json(serde_json::json!({ "presets": presets }))
 }
 
 // ── Rewrite Config Endpoints ────────────────────────────────────────────────

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -294,6 +294,10 @@ async fn main() -> anyhow::Result<()> {
             "/api/proxy/mode/{session_id}",
             get(api_get_proxy_mode).put(api_set_proxy_mode),
         )
+        .route(
+            "/api/proxy/inject/{session_id}",
+            get(api_get_inject_config).put(api_set_inject_config),
+        )
         .route("/api/plans", get(api_list_plans))
         .route(
             "/api/plans/for-session/{session_id}",
@@ -3637,6 +3641,24 @@ async fn api_set_proxy_mode(
     axum::Json(body): axum::Json<SetModeRequest>,
 ) -> axum::Json<serde_json::Value> {
     state.proxy.proxy_modes.set(session_id, body.mode);
+    axum::Json(serde_json::json!({ "ok": true }))
+}
+
+// ── Inject Config Endpoints ─────────────────────────────────────────────────
+
+async fn api_get_inject_config(
+    State(state): State<AppState>,
+    axum::extract::Path(session_id): axum::extract::Path<String>,
+) -> axum::Json<noaide_server::proxy::inject::InjectConfig> {
+    axum::Json(state.proxy.inject_store.get(&session_id))
+}
+
+async fn api_set_inject_config(
+    State(state): State<AppState>,
+    axum::extract::Path(session_id): axum::extract::Path<String>,
+    axum::Json(config): axum::Json<noaide_server::proxy::inject::InjectConfig>,
+) -> axum::Json<serde_json::Value> {
+    state.proxy.inject_store.set(session_id, config);
     axum::Json(serde_json::json!({ "ok": true }))
 }
 

--- a/server/src/proxy/audit.rs
+++ b/server/src/proxy/audit.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 use std::io::Write;
 use std::path::PathBuf;
-use tracing::{debug, warn};
+use tracing::warn;
 
 /// Audit log entry with token usage and cost.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -171,7 +171,13 @@ pub fn extract_tokens(body: &str) -> (String, u64, u64, u64, u64) {
         }
     }
 
-    (model, input_tokens, output_tokens, cache_creation, cache_read)
+    (
+        model,
+        input_tokens,
+        output_tokens,
+        cache_creation,
+        cache_read,
+    )
 }
 
 /// Audit log file path.

--- a/server/src/proxy/audit.rs
+++ b/server/src/proxy/audit.rs
@@ -1,0 +1,370 @@
+//! Audit log + cost tracking — token extraction from SSE responses, cost calculation,
+//! append-only JSONL writer, query with filters, CSV/JSON export.
+
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::path::PathBuf;
+use tracing::{debug, warn};
+
+/// Audit log entry with token usage and cost.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditEntry {
+    pub id: String,
+    pub session_id: Option<String>,
+    pub method: String,
+    pub url: String,
+    pub model: String,
+    pub provider: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cost_usd: f64,
+    pub timestamp: i64,
+    pub latency_ms: u64,
+}
+
+/// Model pricing table (per 1M tokens).
+struct ModelPrice {
+    input: f64,
+    output: f64,
+}
+
+fn model_price(model: &str) -> ModelPrice {
+    // Match on model name prefixes
+    if model.contains("opus") {
+        ModelPrice {
+            input: 15.0,
+            output: 75.0,
+        }
+    } else if model.contains("sonnet") {
+        ModelPrice {
+            input: 3.0,
+            output: 15.0,
+        }
+    } else if model.contains("haiku") {
+        ModelPrice {
+            input: 0.25,
+            output: 1.25,
+        }
+    } else if model.contains("gpt-4o") {
+        ModelPrice {
+            input: 2.5,
+            output: 10.0,
+        }
+    } else if model.contains("gpt-4") {
+        ModelPrice {
+            input: 10.0,
+            output: 30.0,
+        }
+    } else if model.contains("gemini") && model.contains("pro") {
+        ModelPrice {
+            input: 1.25,
+            output: 5.0,
+        }
+    } else if model.contains("gemini") && model.contains("flash") {
+        ModelPrice {
+            input: 0.075,
+            output: 0.3,
+        }
+    } else {
+        // Default: moderate pricing
+        ModelPrice {
+            input: 3.0,
+            output: 15.0,
+        }
+    }
+}
+
+/// Calculate cost in USD from token counts and model.
+pub fn calculate_cost(model: &str, input_tokens: u64, output_tokens: u64) -> f64 {
+    let price = model_price(model);
+    (input_tokens as f64 * price.input + output_tokens as f64 * price.output) / 1_000_000.0
+}
+
+/// Extract token usage from an SSE response body.
+///
+/// Supports Anthropic (usage{}), OpenAI (usage{}), and Gemini (usageMetadata{}).
+pub fn extract_tokens(body: &str) -> (String, u64, u64, u64, u64) {
+    let mut model = String::new();
+    let mut input_tokens = 0u64;
+    let mut output_tokens = 0u64;
+    let mut cache_creation = 0u64;
+    let mut cache_read = 0u64;
+
+    for line in body.lines() {
+        let data = match line.strip_prefix("data: ") {
+            Some(d) if d != "[DONE]" => d,
+            _ => {
+                // Also try non-SSE JSON response
+                if line.starts_with('{') {
+                    line
+                } else {
+                    continue;
+                }
+            }
+        };
+
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(data) {
+            // Anthropic: message_start has model + usage
+            if json.get("type").and_then(|t| t.as_str()) == Some("message_start") {
+                if let Some(msg) = json.get("message") {
+                    if let Some(m) = msg.get("model").and_then(|m| m.as_str()) {
+                        model = m.to_string();
+                    }
+                    if let Some(usage) = msg.get("usage") {
+                        input_tokens = usage
+                            .get("input_tokens")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0);
+                        cache_creation = usage
+                            .get("cache_creation_input_tokens")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0);
+                        cache_read = usage
+                            .get("cache_read_input_tokens")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0);
+                    }
+                }
+            }
+
+            // Anthropic: message_delta has output usage
+            if json.get("type").and_then(|t| t.as_str()) == Some("message_delta") {
+                if let Some(usage) = json.get("usage") {
+                    output_tokens = usage
+                        .get("output_tokens")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(output_tokens);
+                }
+            }
+
+            // OpenAI: usage in final chunk
+            if let Some(usage) = json.get("usage") {
+                if let Some(pt) = usage.get("prompt_tokens").and_then(|v| v.as_u64()) {
+                    input_tokens = pt;
+                }
+                if let Some(ct) = usage.get("completion_tokens").and_then(|v| v.as_u64()) {
+                    output_tokens = ct;
+                }
+                if let Some(m) = json.get("model").and_then(|m| m.as_str()) {
+                    if model.is_empty() {
+                        model = m.to_string();
+                    }
+                }
+            }
+
+            // Gemini: usageMetadata
+            if let Some(meta) = json.get("usageMetadata") {
+                input_tokens = meta
+                    .get("promptTokenCount")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(input_tokens);
+                output_tokens = meta
+                    .get("candidatesTokenCount")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(output_tokens);
+                if let Some(m) = json.get("modelVersion").and_then(|m| m.as_str()) {
+                    model = m.to_string();
+                }
+            }
+        }
+    }
+
+    (model, input_tokens, output_tokens, cache_creation, cache_read)
+}
+
+/// Audit log file path.
+fn audit_log_path() -> PathBuf {
+    PathBuf::from("/data/noaide/audit-log.jsonl")
+}
+
+/// Append an audit entry to the JSONL log file.
+pub fn append_entry(entry: &AuditEntry) {
+    let path = audit_log_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        Ok(mut file) => {
+            if let Ok(json) = serde_json::to_string(entry) {
+                let _ = writeln!(file, "{json}");
+            }
+        }
+        Err(e) => {
+            warn!(error = %e, "failed to write audit log");
+        }
+    }
+}
+
+/// Query audit entries with optional filters.
+pub fn query_entries(
+    session_id: Option<&str>,
+    model: Option<&str>,
+    limit: usize,
+) -> Vec<AuditEntry> {
+    let path = audit_log_path();
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return vec![],
+    };
+
+    let mut entries: Vec<AuditEntry> = content
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .filter(|e: &AuditEntry| {
+            if let Some(sid) = session_id {
+                if e.session_id.as_deref() != Some(sid) {
+                    return false;
+                }
+            }
+            if let Some(m) = model {
+                if !e.model.contains(m) {
+                    return false;
+                }
+            }
+            true
+        })
+        .collect();
+
+    // Most recent first
+    entries.reverse();
+    entries.truncate(limit);
+    entries
+}
+
+/// Export entries as CSV string.
+pub fn export_csv(entries: &[AuditEntry]) -> String {
+    let mut csv = String::from(
+        "timestamp,session_id,model,provider,input_tokens,output_tokens,cache_creation,cache_read,cost_usd,latency_ms,method,url\n",
+    );
+    for e in entries {
+        csv.push_str(&format!(
+            "{},{},{},{},{},{},{},{},{:.6},{},{},{}\n",
+            e.timestamp,
+            e.session_id.as_deref().unwrap_or(""),
+            e.model,
+            e.provider,
+            e.input_tokens,
+            e.output_tokens,
+            e.cache_creation_tokens,
+            e.cache_read_tokens,
+            e.cost_usd,
+            e.latency_ms,
+            e.method,
+            e.url,
+        ));
+    }
+    csv
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_anthropic_tokens() {
+        let body = r#"event: message_start
+data: {"type":"message_start","message":{"model":"claude-opus-4-6","usage":{"input_tokens":1500,"cache_creation_input_tokens":100,"cache_read_input_tokens":50}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello"}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":500}}
+
+"#;
+        let (model, input, output, cache_creation, cache_read) = extract_tokens(body);
+        assert_eq!(model, "claude-opus-4-6");
+        assert_eq!(input, 1500);
+        assert_eq!(output, 500);
+        assert_eq!(cache_creation, 100);
+        assert_eq!(cache_read, 50);
+    }
+
+    #[test]
+    fn extract_openai_tokens() {
+        let body = r#"data: {"choices":[],"usage":{"prompt_tokens":200,"completion_tokens":300},"model":"gpt-4o"}
+data: [DONE]
+"#;
+        let (model, input, output, _, _) = extract_tokens(body);
+        assert_eq!(model, "gpt-4o");
+        assert_eq!(input, 200);
+        assert_eq!(output, 300);
+    }
+
+    #[test]
+    fn extract_gemini_tokens() {
+        let body = r#"data: {"candidates":[],"usageMetadata":{"promptTokenCount":100,"candidatesTokenCount":200},"modelVersion":"gemini-2.0-flash"}
+"#;
+        let (model, input, output, _, _) = extract_tokens(body);
+        assert_eq!(model, "gemini-2.0-flash");
+        assert_eq!(input, 100);
+        assert_eq!(output, 200);
+    }
+
+    #[test]
+    fn calculate_cost_opus() {
+        let cost = calculate_cost("claude-opus-4-6", 1000, 500);
+        // 1000 * 15/1M + 500 * 75/1M = 0.015 + 0.0375 = 0.0525
+        assert!((cost - 0.0525).abs() < 0.001);
+    }
+
+    #[test]
+    fn calculate_cost_haiku() {
+        let cost = calculate_cost("claude-haiku-4-5", 10000, 5000);
+        // 10000 * 0.25/1M + 5000 * 1.25/1M = 0.0025 + 0.00625 = 0.00875
+        assert!((cost - 0.00875).abs() < 0.001);
+    }
+
+    #[test]
+    fn csv_export_format() {
+        let entries = vec![AuditEntry {
+            id: "test-1".to_string(),
+            session_id: Some("session-1".to_string()),
+            method: "POST".to_string(),
+            url: "https://api.anthropic.com/v1/messages".to_string(),
+            model: "claude-opus-4-6".to_string(),
+            provider: "anthropic".to_string(),
+            input_tokens: 1000,
+            output_tokens: 500,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            cost_usd: 0.0525,
+            timestamp: 1712345678000,
+            latency_ms: 250,
+        }];
+        let csv = export_csv(&entries);
+        assert!(csv.starts_with("timestamp,session_id,model"));
+        assert!(csv.contains("1712345678000"));
+        assert!(csv.contains("claude-opus-4-6"));
+        assert!(csv.contains("0.052500"));
+    }
+
+    #[test]
+    fn entry_serde_roundtrip() {
+        let entry = AuditEntry {
+            id: "e1".to_string(),
+            session_id: None,
+            method: "POST".to_string(),
+            url: "test".to_string(),
+            model: "test-model".to_string(),
+            provider: "test".to_string(),
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_creation_tokens: 10,
+            cache_read_tokens: 5,
+            cost_usd: 0.01,
+            timestamp: 0,
+            latency_ms: 100,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        let parsed: AuditEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.model, "test-model");
+        assert_eq!(parsed.input_tokens, 100);
+    }
+}

--- a/server/src/proxy/audit.rs
+++ b/server/src/proxy/audit.rs
@@ -107,8 +107,8 @@ pub fn extract_tokens(body: &str) -> (String, u64, u64, u64, u64) {
 
         if let Ok(json) = serde_json::from_str::<serde_json::Value>(data) {
             // Anthropic: message_start has model + usage
-            if json.get("type").and_then(|t| t.as_str()) == Some("message_start") {
-                if let Some(msg) = json.get("message") {
+            if json.get("type").and_then(|t| t.as_str()) == Some("message_start")
+                && let Some(msg) = json.get("message") {
                     if let Some(m) = msg.get("model").and_then(|m| m.as_str()) {
                         model = m.to_string();
                     }
@@ -127,17 +127,15 @@ pub fn extract_tokens(body: &str) -> (String, u64, u64, u64, u64) {
                             .unwrap_or(0);
                     }
                 }
-            }
 
             // Anthropic: message_delta has output usage
-            if json.get("type").and_then(|t| t.as_str()) == Some("message_delta") {
-                if let Some(usage) = json.get("usage") {
+            if json.get("type").and_then(|t| t.as_str()) == Some("message_delta")
+                && let Some(usage) = json.get("usage") {
                     output_tokens = usage
                         .get("output_tokens")
                         .and_then(|v| v.as_u64())
                         .unwrap_or(output_tokens);
                 }
-            }
 
             // OpenAI: usage in final chunk
             if let Some(usage) = json.get("usage") {
@@ -147,11 +145,10 @@ pub fn extract_tokens(body: &str) -> (String, u64, u64, u64, u64) {
                 if let Some(ct) = usage.get("completion_tokens").and_then(|v| v.as_u64()) {
                     output_tokens = ct;
                 }
-                if let Some(m) = json.get("model").and_then(|m| m.as_str()) {
-                    if model.is_empty() {
+                if let Some(m) = json.get("model").and_then(|m| m.as_str())
+                    && model.is_empty() {
                         model = m.to_string();
                     }
-                }
             }
 
             // Gemini: usageMetadata
@@ -223,16 +220,14 @@ pub fn query_entries(
         .lines()
         .filter_map(|line| serde_json::from_str(line).ok())
         .filter(|e: &AuditEntry| {
-            if let Some(sid) = session_id {
-                if e.session_id.as_deref() != Some(sid) {
+            if let Some(sid) = session_id
+                && e.session_id.as_deref() != Some(sid) {
                     return false;
                 }
-            }
-            if let Some(m) = model {
-                if !e.model.contains(m) {
+            if let Some(m) = model
+                && !e.model.contains(m) {
                     return false;
                 }
-            }
             true
         })
         .collect();

--- a/server/src/proxy/audit.rs
+++ b/server/src/proxy/audit.rs
@@ -108,34 +108,36 @@ pub fn extract_tokens(body: &str) -> (String, u64, u64, u64, u64) {
         if let Ok(json) = serde_json::from_str::<serde_json::Value>(data) {
             // Anthropic: message_start has model + usage
             if json.get("type").and_then(|t| t.as_str()) == Some("message_start")
-                && let Some(msg) = json.get("message") {
-                    if let Some(m) = msg.get("model").and_then(|m| m.as_str()) {
-                        model = m.to_string();
-                    }
-                    if let Some(usage) = msg.get("usage") {
-                        input_tokens = usage
-                            .get("input_tokens")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        cache_creation = usage
-                            .get("cache_creation_input_tokens")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        cache_read = usage
-                            .get("cache_read_input_tokens")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                    }
+                && let Some(msg) = json.get("message")
+            {
+                if let Some(m) = msg.get("model").and_then(|m| m.as_str()) {
+                    model = m.to_string();
                 }
+                if let Some(usage) = msg.get("usage") {
+                    input_tokens = usage
+                        .get("input_tokens")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                    cache_creation = usage
+                        .get("cache_creation_input_tokens")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                    cache_read = usage
+                        .get("cache_read_input_tokens")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                }
+            }
 
             // Anthropic: message_delta has output usage
             if json.get("type").and_then(|t| t.as_str()) == Some("message_delta")
-                && let Some(usage) = json.get("usage") {
-                    output_tokens = usage
-                        .get("output_tokens")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(output_tokens);
-                }
+                && let Some(usage) = json.get("usage")
+            {
+                output_tokens = usage
+                    .get("output_tokens")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(output_tokens);
+            }
 
             // OpenAI: usage in final chunk
             if let Some(usage) = json.get("usage") {
@@ -146,9 +148,10 @@ pub fn extract_tokens(body: &str) -> (String, u64, u64, u64, u64) {
                     output_tokens = ct;
                 }
                 if let Some(m) = json.get("model").and_then(|m| m.as_str())
-                    && model.is_empty() {
-                        model = m.to_string();
-                    }
+                    && model.is_empty()
+                {
+                    model = m.to_string();
+                }
             }
 
             // Gemini: usageMetadata
@@ -221,13 +224,15 @@ pub fn query_entries(
         .filter_map(|line| serde_json::from_str(line).ok())
         .filter(|e: &AuditEntry| {
             if let Some(sid) = session_id
-                && e.session_id.as_deref() != Some(sid) {
-                    return false;
-                }
+                && e.session_id.as_deref() != Some(sid)
+            {
+                return false;
+            }
             if let Some(m) = model
-                && !e.model.contains(m) {
-                    return false;
-                }
+                && !e.model.contains(m)
+            {
+                return false;
+            }
             true
         })
         .collect();

--- a/server/src/proxy/classify.rs
+++ b/server/src/proxy/classify.rs
@@ -49,6 +49,7 @@ static RULES: &[(&str, TrafficCategory)] = &[
     // Update
     ("downloads.claude.ai", TrafficCategory::Update),
     ("update.electronjs.org", TrafficCategory::Update),
+    ("registry.npmjs.org", TrafficCategory::Update),
     // Git
     ("raw.githubusercontent.com", TrafficCategory::Git),
     ("github.com", TrafficCategory::Git),

--- a/server/src/proxy/handler.rs
+++ b/server/src/proxy/handler.rs
@@ -623,6 +623,22 @@ pub async fn proxy_handler(
         req_builder = req_builder.header(name.clone(), value.clone());
     }
 
+    // ── API Key Rotation ──────────────────────────────────────────────
+    // If KeyStore has active keys for this provider, replace the Authorization header.
+    if state.key_store.has_active_keys(provider.label()) {
+        if let Some((_key_id, plaintext_key)) = state.key_store.select_key(provider.label()) {
+            let auth_value = match provider {
+                ApiProvider::Anthropic => format!("{plaintext_key}"),
+                _ => format!("Bearer {plaintext_key}"),
+            };
+            let header_name = match provider {
+                ApiProvider::Anthropic => "x-api-key",
+                _ => "authorization",
+            };
+            req_builder = req_builder.header(header_name, auth_value);
+        }
+    }
+
     if !request_bytes.is_empty() {
         req_builder = req_builder.body(request_bytes.to_vec());
     }
@@ -839,7 +855,33 @@ pub async fn proxy_handler(
                 }
                 cap.push_back(log_entry.clone());
             }
-            let _ = state.event_tx.send(log_entry);
+            let _ = state.event_tx.send(log_entry.clone());
+
+            // ── Audit Log: extract tokens + append ──
+            {
+                let response_str = &log_entry.response_body;
+                let (model, input_tokens, output_tokens, cache_creation, cache_read) =
+                    super::audit::extract_tokens(response_str);
+                if input_tokens > 0 || output_tokens > 0 {
+                    let cost = super::audit::calculate_cost(&model, input_tokens, output_tokens);
+                    let audit_entry = super::audit::AuditEntry {
+                        id: log_entry.id.clone(),
+                        session_id: log_entry.session_id.clone(),
+                        method: log_entry.method.clone(),
+                        url: log_entry.url.clone(),
+                        model,
+                        provider: provider.label().to_string(),
+                        input_tokens,
+                        output_tokens,
+                        cache_creation_tokens: cache_creation,
+                        cache_read_tokens: cache_read,
+                        cost_usd: cost,
+                        timestamp: log_entry.timestamp,
+                        latency_ms: log_entry.latency_ms,
+                    };
+                    super::audit::append_entry(&audit_entry);
+                }
+            }
 
             // Replay the buffered SSE data as the response body.
             // The content-type (text/event-stream) is preserved, so the client's

--- a/server/src/proxy/handler.rs
+++ b/server/src/proxy/handler.rs
@@ -240,6 +240,8 @@ pub struct ProxyState {
     pub network_rules: Arc<super::rules::NetworkRulesEngine>,
     /// Per-session proxy mode (Auto/Manual/Custom/Pure/Lockdown).
     pub proxy_modes: super::modes::ProxyModeStore,
+    /// Per-session system prompt injection configuration.
+    pub inject_store: super::inject::InjectStore,
 }
 
 /// Extract session UUID from `/s/{uuid}/...` proxy path prefix.
@@ -546,8 +548,7 @@ pub async fn proxy_handler(
     } // skip_image_injection
 
     // ── System Prompt Injection ──────────────────────────────────────────
-    // Inform the LLM that it runs inside a browser-based IDE so it can
-    // create media files knowing they will be rendered inline in the chat.
+    // Uses configurable presets from inject module. Default: noaide context.
     // Same skip logic as image injection (only conversation endpoints).
     let skip_system_injection = provider == ApiProvider::GoogleCodeAssist
         && !effective_path.contains("streamGenerateContent");
@@ -555,88 +556,21 @@ pub async fn proxy_handler(
         && !request_bytes.is_empty()
         && let Ok(mut body_json) = serde_json::from_slice::<serde_json::Value>(&request_bytes)
     {
-        let noaide_context = "[noaide] You are running inside noaide, a browser-based IDE. \
-                Media files you create (images, GIFs, SVGs, audio, video) via Bash or Write tools \
-                are rendered inline in the chat. The user sees them directly. \
-                Supported: PNG, JPG, GIF, SVG, WEBP, MP4, WEBM, MP3, WAV, OGG. \
-                To show an image, just create the file (e.g. python3, ImageMagick, ffmpeg, \
-                or write SVG directly).";
+        let inject_config = if let Some(ref sid) = session_id {
+            state.inject_store.get(sid)
+        } else {
+            super::inject::InjectConfig::default()
+        };
+        let injection_text = super::inject::build_injection(&inject_config);
 
-        let mut injected_system = false;
-
-        match provider {
-            ApiProvider::Anthropic => {
-                // Anthropic: body_json["system"] — string or array of content blocks
-                match body_json.get("system") {
-                    Some(serde_json::Value::String(s)) => {
-                        body_json["system"] =
-                            serde_json::Value::String(format!("{s}\n\n{noaide_context}"));
-                        injected_system = true;
-                    }
-                    Some(serde_json::Value::Array(_)) => {
-                        if let Some(arr) = body_json["system"].as_array_mut() {
-                            arr.push(serde_json::json!({
-                                "type": "text",
-                                "text": noaide_context,
-                            }));
-                            injected_system = true;
-                        }
-                    }
-                    _ => {
-                        // No system field — create it
-                        body_json["system"] = serde_json::Value::String(noaide_context.to_string());
-                        injected_system = true;
-                    }
-                }
-            }
-            ApiProvider::GoogleCodeAssist | ApiProvider::Google => {
-                // Google: body_json["system_instruction"]["parts"] or
-                // body_json["request"]["system_instruction"]["parts"]
-                let targets = [
-                    vec!["system_instruction", "parts"],
-                    vec!["request", "system_instruction", "parts"],
-                ];
-                for target in &targets {
-                    let mut cursor = &mut body_json;
-                    let mut found = true;
-                    for (i, key) in target.iter().enumerate() {
-                        if i == target.len() - 1 {
-                            // Last key — should be "parts" array
-                            if let Some(arr) = cursor.get_mut(*key).and_then(|v| v.as_array_mut()) {
-                                arr.push(serde_json::json!({"text": noaide_context}));
-                                injected_system = true;
-                            } else {
-                                found = false;
-                            }
-                        } else if cursor.get(*key).is_some() {
-                            cursor = &mut cursor[*key];
-                        } else {
-                            found = false;
-                            break;
-                        }
-                    }
-                    if found && injected_system {
-                        break;
-                    }
-                }
-                // If no system_instruction exists, create it
-                if !injected_system {
-                    body_json["system_instruction"] = serde_json::json!({
-                        "parts": [{"text": noaide_context}]
-                    });
-                    injected_system = true;
-                }
-            }
-            _ => {
-                // OpenAI/ChatGPT: No system prompt injection for now
-                // (Codex uses a different format)
-            }
-        }
-
-        if injected_system && let Ok(modified) = serde_json::to_vec(&body_json) {
+        if !injection_text.is_empty()
+            && super::inject::inject_into_body(&mut body_json, provider, &injection_text)
+            && let Ok(modified) = serde_json::to_vec(&body_json)
+        {
             debug!(
                 provider = %provider.label(),
-                "injected noaide system context into API request"
+                presets = ?inject_config.presets,
+                "injected system prompt into API request"
             );
             request_bytes = Bytes::from(modified);
         }

--- a/server/src/proxy/handler.rs
+++ b/server/src/proxy/handler.rs
@@ -244,6 +244,8 @@ pub struct ProxyState {
     pub inject_store: super::inject::InjectStore,
     /// Per-session request body rewrite configuration.
     pub rewrite_store: super::rewrite::RewriteStore,
+    /// API key store for key rotation.
+    pub key_store: super::keys::KeyStore,
 }
 
 /// Extract session UUID from `/s/{uuid}/...` proxy path prefix.

--- a/server/src/proxy/handler.rs
+++ b/server/src/proxy/handler.rs
@@ -589,9 +589,7 @@ pub async fn proxy_handler(
             super::rewrite::RewriteConfig::default()
         };
         if rewrite_config.is_active() {
-            if let Ok(mut body_json) =
-                serde_json::from_slice::<serde_json::Value>(&request_bytes)
-            {
+            if let Ok(mut body_json) = serde_json::from_slice::<serde_json::Value>(&request_bytes) {
                 if super::rewrite::apply_rewrites(&mut body_json, provider, &rewrite_config) {
                     if let Ok(modified) = serde_json::to_vec(&body_json) {
                         request_bytes = Bytes::from(modified);
@@ -1524,8 +1522,7 @@ where
 
     // Prepend peeked bytes back into the stream for hyper to parse
     let prefix = bytes::Bytes::copy_from_slice(&peek_buf[..peek_len]);
-    let prefixed_client =
-        hyper_util::rt::TokioIo::new(PrefixedIo::new(prefix, client_tls));
+    let prefixed_client = hyper_util::rt::TokioIo::new(PrefixedIo::new(prefix, client_tls));
     let target_io = hyper_util::rt::TokioIo::new(target_tls);
 
     // Establish hyper HTTP/1.1 client connection to real target
@@ -1846,15 +1843,21 @@ async fn handle_websocket_proxy(
         let name_str = name.as_str().to_lowercase();
         // Forward auth, cookies, and provider-specific headers — skip hop-by-hop
         match name_str.as_str() {
-            "host" | "upgrade" | "connection" | "sec-websocket-key"
-            | "sec-websocket-version" | "sec-websocket-extensions"
+            "host"
+            | "upgrade"
+            | "connection"
+            | "sec-websocket-key"
+            | "sec-websocket-version"
+            | "sec-websocket-extensions"
             | "sec-websocket-protocol" => continue,
             _ => {
                 if let Ok(header_name) =
                     tokio_tungstenite::tungstenite::http::HeaderName::from_bytes(name.as_ref())
                 {
                     if let Ok(header_value) =
-                        tokio_tungstenite::tungstenite::http::HeaderValue::from_bytes(value.as_bytes())
+                        tokio_tungstenite::tungstenite::http::HeaderValue::from_bytes(
+                            value.as_bytes(),
+                        )
                     {
                         ws_request = ws_request.header(header_name, header_value);
                     }
@@ -1872,15 +1875,18 @@ async fn handle_websocket_proxy(
     };
 
     // Connect to upstream WebSocket
-    let (upstream_ws, _upstream_response) =
-        match tokio_tungstenite::connect_async(ws_request).await {
-            Ok(pair) => pair,
-            Err(e) => {
-                warn!(error = %e, url = %ws_url, "failed to connect to upstream WebSocket");
-                return (StatusCode::BAD_GATEWAY, "WebSocket upstream connection failed")
-                    .into_response();
-            }
-        };
+    let (upstream_ws, _upstream_response) = match tokio_tungstenite::connect_async(ws_request).await
+    {
+        Ok(pair) => pair,
+        Err(e) => {
+            warn!(error = %e, url = %ws_url, "failed to connect to upstream WebSocket");
+            return (
+                StatusCode::BAD_GATEWAY,
+                "WebSocket upstream connection failed",
+            )
+                .into_response();
+        }
+    };
 
     info!(url = %ws_url, session_id = ?session_id, "upstream WebSocket connected");
 

--- a/server/src/proxy/handler.rs
+++ b/server/src/proxy/handler.rs
@@ -16,6 +16,69 @@ use tracing::{debug, info, warn};
 
 use super::mitm::{self, ApiRequestLog};
 
+/// A stream that prepends buffered bytes before delegating to the inner stream.
+/// Reads: first returns prefix bytes, then reads from inner.
+/// Writes: always writes to inner (the prefix is read-only).
+struct PrefixedIo<S> {
+    prefix: bytes::Bytes,
+    prefix_pos: usize,
+    inner: S,
+}
+
+impl<S> PrefixedIo<S> {
+    fn new(prefix: bytes::Bytes, inner: S) -> Self {
+        Self {
+            prefix,
+            prefix_pos: 0,
+            inner,
+        }
+    }
+}
+
+impl<S: tokio::io::AsyncRead + Unpin> tokio::io::AsyncRead for PrefixedIo<S> {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        // Serve prefix bytes first
+        if this.prefix_pos < this.prefix.len() {
+            let remaining = &this.prefix[this.prefix_pos..];
+            let to_copy = remaining.len().min(buf.remaining());
+            buf.put_slice(&remaining[..to_copy]);
+            this.prefix_pos += to_copy;
+            return std::task::Poll::Ready(Ok(()));
+        }
+        // Then delegate to inner stream
+        std::pin::Pin::new(&mut this.inner).poll_read(cx, buf)
+    }
+}
+
+impl<S: tokio::io::AsyncWrite + Unpin> tokio::io::AsyncWrite for PrefixedIo<S> {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        std::pin::Pin::new(&mut self.get_mut().inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::pin::Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::pin::Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+    }
+}
+
 /// Try to decompress a zstd-encoded request body for logging.
 /// Codex CLI sends `content-encoding: zstd` on request bodies.
 /// Original compressed bytes are still forwarded to upstream unchanged.
@@ -1438,7 +1501,7 @@ where
     // Prepend peeked bytes back into the stream for hyper to parse
     let prefix = bytes::Bytes::copy_from_slice(&peek_buf[..peek_len]);
     let prefixed_client =
-        hyper_util::rt::TokioIo::new(tokio::io::join(std::io::Cursor::new(prefix), client_tls));
+        hyper_util::rt::TokioIo::new(PrefixedIo::new(prefix, client_tls));
     let target_io = hyper_util::rt::TokioIo::new(target_tls);
 
     // Establish hyper HTTP/1.1 client connection to real target

--- a/server/src/proxy/handler.rs
+++ b/server/src/proxy/handler.rs
@@ -588,15 +588,12 @@ pub async fn proxy_handler(
         } else {
             super::rewrite::RewriteConfig::default()
         };
-        if rewrite_config.is_active() {
-            if let Ok(mut body_json) = serde_json::from_slice::<serde_json::Value>(&request_bytes) {
-                if super::rewrite::apply_rewrites(&mut body_json, provider, &rewrite_config) {
-                    if let Ok(modified) = serde_json::to_vec(&body_json) {
+        if rewrite_config.is_active()
+            && let Ok(mut body_json) = serde_json::from_slice::<serde_json::Value>(&request_bytes)
+                && super::rewrite::apply_rewrites(&mut body_json, provider, &rewrite_config)
+                    && let Ok(modified) = serde_json::to_vec(&body_json) {
                         request_bytes = Bytes::from(modified);
                     }
-                }
-            }
-        }
     }
 
     // ── Build forwarding request ────────────────────────────────────────
@@ -623,10 +620,10 @@ pub async fn proxy_handler(
 
     // ── API Key Rotation ──────────────────────────────────────────────
     // If KeyStore has active keys for this provider, replace the Authorization header.
-    if state.key_store.has_active_keys(provider.label()) {
-        if let Some((_key_id, plaintext_key)) = state.key_store.select_key(provider.label()) {
+    if state.key_store.has_active_keys(provider.label())
+        && let Some((_key_id, plaintext_key)) = state.key_store.select_key(provider.label()) {
             let auth_value = match provider {
-                ApiProvider::Anthropic => format!("{plaintext_key}"),
+                ApiProvider::Anthropic => plaintext_key.to_string(),
                 _ => format!("Bearer {plaintext_key}"),
             };
             let header_name = match provider {
@@ -635,7 +632,6 @@ pub async fn proxy_handler(
             };
             req_builder = req_builder.header(header_name, auth_value);
         }
-    }
 
     if !request_bytes.is_empty() {
         req_builder = req_builder.body(request_bytes.to_vec());
@@ -1853,15 +1849,13 @@ async fn handle_websocket_proxy(
             _ => {
                 if let Ok(header_name) =
                     tokio_tungstenite::tungstenite::http::HeaderName::from_bytes(name.as_ref())
-                {
-                    if let Ok(header_value) =
+                    && let Ok(header_value) =
                         tokio_tungstenite::tungstenite::http::HeaderValue::from_bytes(
                             value.as_bytes(),
                         )
                     {
                         ws_request = ws_request.header(header_name, header_value);
                     }
-                }
             }
         }
     }

--- a/server/src/proxy/handler.rs
+++ b/server/src/proxy/handler.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use axum::body::Body;
-use axum::extract::State;
+use axum::extract::{FromRequest, State};
 use axum::http::{HeaderMap, Method, StatusCode, Uri};
 use axum::response::{IntoResponse, Response};
 use base64::Engine as _;
@@ -94,7 +94,7 @@ fn try_decompress_request(body: &[u8], headers: &[(String, String)]) -> Option<V
 }
 
 /// Maximum number of captured requests kept in memory
-const MAX_CAPTURED_REQUESTS: usize = 1000;
+pub(crate) const MAX_CAPTURED_REQUESTS: usize = 1000;
 
 /// Supported upstream API providers
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -262,16 +262,21 @@ fn extract_session_prefix(path: &str) -> (Option<String>, &str) {
 }
 
 /// Main proxy handler — intercepts requests, detects provider, forwards to upstream,
-/// logs redacted request/response, and publishes events
+/// logs redacted request/response, and publishes events.
+///
+/// Takes the full `axum::extract::Request` so WebSocket upgrades can be handled
+/// BEFORE the body is consumed (hyper pitfall: upgrade requires the original request).
 pub async fn proxy_handler(
     State(state): State<Arc<ProxyState>>,
-    method: Method,
-    uri: Uri,
-    headers: HeaderMap,
-    body: Body,
+    req: axum::extract::Request,
 ) -> Response {
     let start = Instant::now();
     let request_id = uuid::Uuid::new_v4().to_string();
+
+    // Decompose request into parts we need
+    let method = req.method().clone();
+    let uri = req.uri().clone();
+    let headers = req.headers().clone();
 
     // Extract session ID from /s/{uuid}/... prefix (managed sessions only)
     let path = uri.path();
@@ -291,6 +296,22 @@ pub async fn proxy_handler(
     let base_url = provider.base_url();
     let query = uri.query().map(|q| format!("?{q}")).unwrap_or_default();
     let target_url = format!("{base_url}{effective_path}{query}");
+
+    // ── WebSocket Upgrade Detection ────────────────────────────────────
+    // Check BEFORE body.collect() — consuming the body prevents hyper upgrade.
+    // Codex WebSocket goes through reverse proxy (chatgpt.com in NO_PROXY).
+    if super::websocket::is_websocket_upgrade(&headers) {
+        info!(
+            request_id = %request_id,
+            target_url = %target_url,
+            session_id = ?session_id,
+            "WebSocket upgrade detected, establishing upstream connection"
+        );
+        return handle_websocket_proxy(state, session_id, target_url, req).await;
+    }
+
+    // Now consume the body (safe — not a WebSocket upgrade)
+    let body = req.into_body();
 
     // Collect request body (mutable — intercept gate may replace it)
     let mut request_bytes: Bytes = match body.collect().await {
@@ -1790,6 +1811,91 @@ async fn log_tunnel_metadata(
         "provider" => "tunnel",
     )
     .increment(1);
+}
+
+/// Handle a WebSocket upgrade through the reverse proxy.
+///
+/// Flow:
+/// 1. Connect to upstream via tokio-tungstenite with forwarded headers
+/// 2. Use axum's WebSocketUpgrade to upgrade the client connection
+/// 3. Relay frames bidirectionally, logging text frames as ApiRequestLog
+async fn handle_websocket_proxy(
+    state: Arc<ProxyState>,
+    session_id: Option<String>,
+    target_url: String,
+    req: axum::extract::Request,
+) -> Response {
+    use axum::extract::ws::WebSocketUpgrade;
+
+    // Build the upstream WebSocket URL (wss:// for https://)
+    let ws_url = target_url
+        .replacen("https://", "wss://", 1)
+        .replacen("http://", "ws://", 1);
+
+    // Forward relevant headers to upstream (auth, cookies, etc.)
+    let mut ws_request = tokio_tungstenite::tungstenite::http::Request::builder()
+        .uri(&ws_url)
+        .method("GET");
+
+    // Copy important headers from the original request
+    let original_headers = req.headers();
+    for (name, value) in original_headers.iter() {
+        let name_str = name.as_str().to_lowercase();
+        // Forward auth, cookies, and provider-specific headers — skip hop-by-hop
+        match name_str.as_str() {
+            "host" | "upgrade" | "connection" | "sec-websocket-key"
+            | "sec-websocket-version" | "sec-websocket-extensions"
+            | "sec-websocket-protocol" => continue,
+            _ => {
+                if let Ok(header_name) =
+                    tokio_tungstenite::tungstenite::http::HeaderName::from_bytes(name.as_ref())
+                {
+                    if let Ok(header_value) =
+                        tokio_tungstenite::tungstenite::http::HeaderValue::from_bytes(value.as_bytes())
+                    {
+                        ws_request = ws_request.header(header_name, header_value);
+                    }
+                }
+            }
+        }
+    }
+
+    let ws_request = match ws_request.body(()) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(error = %e, "failed to build upstream WS request");
+            return (StatusCode::BAD_GATEWAY, "Bad Gateway").into_response();
+        }
+    };
+
+    // Connect to upstream WebSocket
+    let (upstream_ws, _upstream_response) =
+        match tokio_tungstenite::connect_async(ws_request).await {
+            Ok(pair) => pair,
+            Err(e) => {
+                warn!(error = %e, url = %ws_url, "failed to connect to upstream WebSocket");
+                return (StatusCode::BAD_GATEWAY, "WebSocket upstream connection failed")
+                    .into_response();
+            }
+        };
+
+    info!(url = %ws_url, session_id = ?session_id, "upstream WebSocket connected");
+
+    // Extract axum's WebSocketUpgrade from the original request
+    let ws_upgrade = match WebSocketUpgrade::from_request(req, &()).await {
+        Ok(ws) => ws,
+        Err(e) => {
+            warn!(error = %e, "failed to extract WebSocket upgrade from request");
+            return (StatusCode::BAD_REQUEST, "WebSocket upgrade failed").into_response();
+        }
+    };
+
+    // Perform the upgrade and start frame relay
+    let session_clone = session_id.clone();
+    let url_clone = ws_url.clone();
+    ws_upgrade.on_upgrade(move |client_ws| {
+        super::websocket::relay_frames(client_ws, upstream_ws, session_clone, url_clone, state)
+    })
 }
 
 #[cfg(test)]

--- a/server/src/proxy/handler.rs
+++ b/server/src/proxy/handler.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use axum::body::Body;
 use axum::extract::{FromRequest, State};
-use axum::http::{HeaderMap, Method, StatusCode, Uri};
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use base64::Engine as _;
 use bytes::Bytes;
@@ -242,6 +242,8 @@ pub struct ProxyState {
     pub proxy_modes: super::modes::ProxyModeStore,
     /// Per-session system prompt injection configuration.
     pub inject_store: super::inject::InjectStore,
+    /// Per-session request body rewrite configuration.
+    pub rewrite_store: super::rewrite::RewriteStore,
 }
 
 /// Extract session UUID from `/s/{uuid}/...` proxy path prefix.
@@ -573,6 +575,27 @@ pub async fn proxy_handler(
                 "injected system prompt into API request"
             );
             request_bytes = Bytes::from(modified);
+        }
+    }
+
+    // ── Request Body Rewrite ──────────────────────────────────────────
+    // Apply per-session model override, temperature, max_tokens, pure mode.
+    if !request_bytes.is_empty() {
+        let rewrite_config = if let Some(ref sid) = session_id {
+            state.rewrite_store.get(sid)
+        } else {
+            super::rewrite::RewriteConfig::default()
+        };
+        if rewrite_config.is_active() {
+            if let Ok(mut body_json) =
+                serde_json::from_slice::<serde_json::Value>(&request_bytes)
+            {
+                if super::rewrite::apply_rewrites(&mut body_json, provider, &rewrite_config) {
+                    if let Ok(modified) = serde_json::to_vec(&body_json) {
+                        request_bytes = Bytes::from(modified);
+                    }
+                }
+            }
         }
     }
 

--- a/server/src/proxy/handler.rs
+++ b/server/src/proxy/handler.rs
@@ -238,6 +238,8 @@ pub struct ProxyState {
     pub ca: Option<Arc<super::tls_mitm::CaAuthority>>,
     /// Per-session network rules for CONNECT MITM traffic (Block/Allow/Delay).
     pub network_rules: Arc<super::rules::NetworkRulesEngine>,
+    /// Per-session proxy mode (Auto/Manual/Custom/Pure/Lockdown).
+    pub proxy_modes: super::modes::ProxyModeStore,
 }
 
 /// Extract session UUID from `/s/{uuid}/...` proxy path prefix.

--- a/server/src/proxy/handler.rs
+++ b/server/src/proxy/handler.rs
@@ -590,10 +590,11 @@ pub async fn proxy_handler(
         };
         if rewrite_config.is_active()
             && let Ok(mut body_json) = serde_json::from_slice::<serde_json::Value>(&request_bytes)
-                && super::rewrite::apply_rewrites(&mut body_json, provider, &rewrite_config)
-                    && let Ok(modified) = serde_json::to_vec(&body_json) {
-                        request_bytes = Bytes::from(modified);
-                    }
+            && super::rewrite::apply_rewrites(&mut body_json, provider, &rewrite_config)
+            && let Ok(modified) = serde_json::to_vec(&body_json)
+        {
+            request_bytes = Bytes::from(modified);
+        }
     }
 
     // ── Build forwarding request ────────────────────────────────────────
@@ -621,17 +622,18 @@ pub async fn proxy_handler(
     // ── API Key Rotation ──────────────────────────────────────────────
     // If KeyStore has active keys for this provider, replace the Authorization header.
     if state.key_store.has_active_keys(provider.label())
-        && let Some((_key_id, plaintext_key)) = state.key_store.select_key(provider.label()) {
-            let auth_value = match provider {
-                ApiProvider::Anthropic => plaintext_key.to_string(),
-                _ => format!("Bearer {plaintext_key}"),
-            };
-            let header_name = match provider {
-                ApiProvider::Anthropic => "x-api-key",
-                _ => "authorization",
-            };
-            req_builder = req_builder.header(header_name, auth_value);
-        }
+        && let Some((_key_id, plaintext_key)) = state.key_store.select_key(provider.label())
+    {
+        let auth_value = match provider {
+            ApiProvider::Anthropic => plaintext_key.to_string(),
+            _ => format!("Bearer {plaintext_key}"),
+        };
+        let header_name = match provider {
+            ApiProvider::Anthropic => "x-api-key",
+            _ => "authorization",
+        };
+        req_builder = req_builder.header(header_name, auth_value);
+    }
 
     if !request_bytes.is_empty() {
         req_builder = req_builder.body(request_bytes.to_vec());
@@ -1853,9 +1855,9 @@ async fn handle_websocket_proxy(
                         tokio_tungstenite::tungstenite::http::HeaderValue::from_bytes(
                             value.as_bytes(),
                         )
-                    {
-                        ws_request = ws_request.header(header_name, header_value);
-                    }
+                {
+                    ws_request = ws_request.header(header_name, header_value);
+                }
             }
         }
     }

--- a/server/src/proxy/inject.rs
+++ b/server/src/proxy/inject.rs
@@ -28,39 +28,51 @@ pub enum Preset {
 impl Preset {
     pub fn text(&self) -> &'static str {
         match self {
-            Preset::AntiLaziness => "\
+            Preset::AntiLaziness => {
+                "\
 [ANTI-LAZINESS] You MUST complete ALL requested work. Never use shortcuts like \
 '// ... rest of the code remains the same', '... (remaining code omitted)', or \
 similar truncation patterns. If asked to write code, write the COMPLETE code. \
 If asked to make changes, show the FULL changed file, not just snippets. \
-Incomplete work is UNACCEPTABLE.",
+Incomplete work is UNACCEPTABLE."
+            }
 
-            Preset::VerifyEvidence => "\
+            Preset::VerifyEvidence => {
+                "\
 [VERIFY-EVIDENCE] For every claim or assertion you make, provide concrete evidence: \
 exact command output, file contents, test results, or measurements. \
 Never write PASS, OK, or 'verified' without an actual executed command and its output. \
-'Code looks correct' is NOT evidence. Default state of any claim is UNTESTED.",
+'Code looks correct' is NOT evidence. Default state of any claim is UNTESTED."
+            }
 
-            Preset::Speed => "\
+            Preset::Speed => {
+                "\
 [SPEED] Be concise and efficient. Skip preamble, go straight to the answer. \
-No unnecessary explanations unless asked. Prefer bullet points over paragraphs.",
+No unnecessary explanations unless asked. Prefer bullet points over paragraphs."
+            }
 
-            Preset::Verbose => "\
+            Preset::Verbose => {
+                "\
 [VERBOSE] Provide detailed explanations with step-by-step reasoning. \
-Show your thought process. Include relevant context and alternatives considered.",
+Show your thought process. Include relevant context and alternatives considered."
+            }
 
-            Preset::GermanOnly => "\
+            Preset::GermanOnly => {
+                "\
 [SPRACHE] Antworte AUSSCHLIESSLICH auf Deutsch. Technische Fachbegriffe und \
 Code-Identifier bleiben auf Englisch, aber alle Erklaerungen, Kommentare und \
-Kommunikation MUESSEN auf Deutsch sein.",
+Kommunikation MUESSEN auf Deutsch sein."
+            }
 
-            Preset::NoaideContext => "\
+            Preset::NoaideContext => {
+                "\
 [noaide] You are running inside noaide, a browser-based IDE. \
 Media files you create (images, GIFs, SVGs, audio, video) via Bash or Write tools \
 are rendered inline in the chat. The user sees them directly. \
 Supported: PNG, JPG, GIF, SVG, WEBP, MP4, WEBM, MP3, WAV, OGG. \
 To show an image, just create the file (e.g. python3, ImageMagick, ffmpeg, \
-or write SVG directly).",
+or write SVG directly)."
+            }
         }
     }
 
@@ -336,7 +348,12 @@ mod tests {
         let messages = body["messages"].as_array().unwrap();
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0]["role"], "system");
-        assert!(messages[0]["content"].as_str().unwrap().contains("system text"));
+        assert!(
+            messages[0]["content"]
+                .as_str()
+                .unwrap()
+                .contains("system text")
+        );
     }
 
     #[test]

--- a/server/src/proxy/inject.rs
+++ b/server/src/proxy/inject.rs
@@ -1,0 +1,349 @@
+//! System prompt injection with configurable presets.
+//!
+//! Supports injecting text into API request bodies for Anthropic, Google, and OpenAI
+//! providers. Presets provide pre-defined injection texts; custom text can also be used.
+
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+/// Available injection presets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum Preset {
+    /// Prevent lazy/incomplete responses
+    AntiLaziness,
+    /// Require evidence/verification for claims
+    VerifyEvidence,
+    /// Optimize for speed/conciseness
+    Speed,
+    /// Request verbose/detailed responses
+    Verbose,
+    /// Respond only in German
+    GermanOnly,
+    /// noaide media-aware context (built-in default)
+    NoaideContext,
+}
+
+impl Preset {
+    pub fn text(&self) -> &'static str {
+        match self {
+            Preset::AntiLaziness => "\
+[ANTI-LAZINESS] You MUST complete ALL requested work. Never use shortcuts like \
+'// ... rest of the code remains the same', '... (remaining code omitted)', or \
+similar truncation patterns. If asked to write code, write the COMPLETE code. \
+If asked to make changes, show the FULL changed file, not just snippets. \
+Incomplete work is UNACCEPTABLE.",
+
+            Preset::VerifyEvidence => "\
+[VERIFY-EVIDENCE] For every claim or assertion you make, provide concrete evidence: \
+exact command output, file contents, test results, or measurements. \
+Never write PASS, OK, or 'verified' without an actual executed command and its output. \
+'Code looks correct' is NOT evidence. Default state of any claim is UNTESTED.",
+
+            Preset::Speed => "\
+[SPEED] Be concise and efficient. Skip preamble, go straight to the answer. \
+No unnecessary explanations unless asked. Prefer bullet points over paragraphs.",
+
+            Preset::Verbose => "\
+[VERBOSE] Provide detailed explanations with step-by-step reasoning. \
+Show your thought process. Include relevant context and alternatives considered.",
+
+            Preset::GermanOnly => "\
+[SPRACHE] Antworte AUSSCHLIESSLICH auf Deutsch. Technische Fachbegriffe und \
+Code-Identifier bleiben auf Englisch, aber alle Erklaerungen, Kommentare und \
+Kommunikation MUESSEN auf Deutsch sein.",
+
+            Preset::NoaideContext => "\
+[noaide] You are running inside noaide, a browser-based IDE. \
+Media files you create (images, GIFs, SVGs, audio, video) via Bash or Write tools \
+are rendered inline in the chat. The user sees them directly. \
+Supported: PNG, JPG, GIF, SVG, WEBP, MP4, WEBM, MP3, WAV, OGG. \
+To show an image, just create the file (e.g. python3, ImageMagick, ffmpeg, \
+or write SVG directly).",
+        }
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Preset::AntiLaziness => "Anti-Laziness",
+            Preset::VerifyEvidence => "Verify Evidence",
+            Preset::Speed => "Speed",
+            Preset::Verbose => "Verbose",
+            Preset::GermanOnly => "German Only",
+            Preset::NoaideContext => "noaide Context",
+        }
+    }
+}
+
+/// Per-session injection configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InjectConfig {
+    pub presets: Vec<Preset>,
+    pub custom_text: Option<String>,
+}
+
+impl Default for InjectConfig {
+    fn default() -> Self {
+        Self {
+            presets: vec![Preset::NoaideContext],
+            custom_text: None,
+        }
+    }
+}
+
+/// Build the full injection text from active presets + custom text.
+pub fn build_injection(config: &InjectConfig) -> String {
+    let mut parts: Vec<&str> = config.presets.iter().map(|p| p.text()).collect();
+    if let Some(ref custom) = config.custom_text {
+        if !custom.is_empty() {
+            parts.push(custom);
+        }
+    }
+    parts.join("\n\n")
+}
+
+/// Inject text into an API request body for the given provider.
+///
+/// Returns `true` if injection was successful.
+pub fn inject_into_body(
+    body: &mut serde_json::Value,
+    provider: super::handler::ApiProvider,
+    text: &str,
+) -> bool {
+    use super::handler::ApiProvider;
+
+    match provider {
+        ApiProvider::Anthropic => {
+            match body.get("system") {
+                Some(serde_json::Value::String(s)) => {
+                    body["system"] = serde_json::Value::String(format!("{s}\n\n{text}"));
+                }
+                Some(serde_json::Value::Array(_)) => {
+                    if let Some(arr) = body["system"].as_array_mut() {
+                        arr.push(serde_json::json!({
+                            "type": "text",
+                            "text": text,
+                        }));
+                    }
+                }
+                _ => {
+                    body["system"] = serde_json::Value::String(text.to_string());
+                }
+            }
+            true
+        }
+        ApiProvider::GoogleCodeAssist | ApiProvider::Google => {
+            // Try existing system_instruction.parts or request.system_instruction.parts
+            let targets = [
+                vec!["system_instruction", "parts"],
+                vec!["request", "system_instruction", "parts"],
+            ];
+            for target in &targets {
+                let mut cursor = &mut *body;
+                let mut found = true;
+                for (i, key) in target.iter().enumerate() {
+                    if i == target.len() - 1 {
+                        if let Some(arr) = cursor.get_mut(*key).and_then(|v| v.as_array_mut()) {
+                            arr.push(serde_json::json!({"text": text}));
+                            return true;
+                        }
+                        found = false;
+                    } else if cursor.get(*key).is_some() {
+                        cursor = &mut cursor[*key];
+                    } else {
+                        found = false;
+                        break;
+                    }
+                }
+                if found {
+                    return true;
+                }
+            }
+            // Create system_instruction if none exists
+            body["system_instruction"] = serde_json::json!({
+                "parts": [{"text": text}]
+            });
+            true
+        }
+        ApiProvider::OpenAI | ApiProvider::ChatGPT => {
+            // Prepend system message to messages array (or input array for Codex)
+            let msg_key = if body.get("input").is_some() {
+                "input"
+            } else {
+                "messages"
+            };
+            if let Some(arr) = body.get_mut(msg_key).and_then(|v| v.as_array_mut()) {
+                arr.insert(
+                    0,
+                    serde_json::json!({
+                        "role": "system",
+                        "content": text,
+                    }),
+                );
+                true
+            } else {
+                false
+            }
+        }
+    }
+}
+
+/// Per-session inject config storage.
+pub struct InjectStore {
+    configs: DashMap<String, InjectConfig>,
+}
+
+impl InjectStore {
+    pub fn new() -> Self {
+        Self {
+            configs: DashMap::new(),
+        }
+    }
+
+    pub fn get(&self, session_id: &str) -> InjectConfig {
+        self.configs
+            .get(session_id)
+            .map(|r| r.value().clone())
+            .unwrap_or_default()
+    }
+
+    pub fn set(&self, session_id: String, config: InjectConfig) {
+        self.configs.insert(session_id, config);
+    }
+}
+
+impl Default for InjectStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_has_noaide_preset() {
+        let config = InjectConfig::default();
+        assert_eq!(config.presets, vec![Preset::NoaideContext]);
+    }
+
+    #[test]
+    fn build_injection_combines_presets_and_custom() {
+        let config = InjectConfig {
+            presets: vec![Preset::AntiLaziness, Preset::GermanOnly],
+            custom_text: Some("Custom instruction".to_string()),
+        };
+        let text = build_injection(&config);
+        assert!(text.contains("[ANTI-LAZINESS]"));
+        assert!(text.contains("[SPRACHE]"));
+        assert!(text.contains("Custom instruction"));
+    }
+
+    #[test]
+    fn inject_anthropic_string_system() {
+        let mut body = serde_json::json!({
+            "model": "claude-opus-4-6",
+            "system": "You are helpful.",
+            "messages": []
+        });
+        let result = inject_into_body(
+            &mut body,
+            super::super::handler::ApiProvider::Anthropic,
+            "injected text",
+        );
+        assert!(result);
+        let system = body["system"].as_str().unwrap();
+        assert!(system.contains("You are helpful."));
+        assert!(system.contains("injected text"));
+    }
+
+    #[test]
+    fn inject_anthropic_array_system() {
+        let mut body = serde_json::json!({
+            "model": "claude-opus-4-6",
+            "system": [{"type": "text", "text": "existing"}],
+            "messages": []
+        });
+        let result = inject_into_body(
+            &mut body,
+            super::super::handler::ApiProvider::Anthropic,
+            "injected",
+        );
+        assert!(result);
+        let arr = body["system"].as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn inject_anthropic_no_system() {
+        let mut body = serde_json::json!({
+            "model": "claude-opus-4-6",
+            "messages": []
+        });
+        let result = inject_into_body(
+            &mut body,
+            super::super::handler::ApiProvider::Anthropic,
+            "new system",
+        );
+        assert!(result);
+        assert_eq!(body["system"].as_str().unwrap(), "new system");
+    }
+
+    #[test]
+    fn inject_google_system_instruction() {
+        let mut body = serde_json::json!({
+            "system_instruction": {"parts": [{"text": "existing"}]},
+            "contents": []
+        });
+        let result = inject_into_body(
+            &mut body,
+            super::super::handler::ApiProvider::Google,
+            "injected",
+        );
+        assert!(result);
+        let parts = body["system_instruction"]["parts"].as_array().unwrap();
+        assert_eq!(parts.len(), 2);
+    }
+
+    #[test]
+    fn inject_google_creates_system_instruction() {
+        let mut body = serde_json::json!({
+            "contents": []
+        });
+        let result = inject_into_body(
+            &mut body,
+            super::super::handler::ApiProvider::Google,
+            "new instruction",
+        );
+        assert!(result);
+        assert!(body["system_instruction"]["parts"].is_array());
+    }
+
+    #[test]
+    fn inject_openai_prepends_system_message() {
+        let mut body = serde_json::json!({
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hello"}]
+        });
+        let result = inject_into_body(
+            &mut body,
+            super::super::handler::ApiProvider::OpenAI,
+            "system text",
+        );
+        assert!(result);
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0]["role"], "system");
+        assert!(messages[0]["content"].as_str().unwrap().contains("system text"));
+    }
+
+    #[test]
+    fn preset_serde_roundtrip() {
+        let json = serde_json::to_string(&Preset::AntiLaziness).unwrap();
+        assert_eq!(json, "\"anti_laziness\"");
+        let parsed: Preset = serde_json::from_str("\"verify_evidence\"").unwrap();
+        assert_eq!(parsed, Preset::VerifyEvidence);
+    }
+}

--- a/server/src/proxy/inject.rs
+++ b/server/src/proxy/inject.rs
@@ -108,9 +108,10 @@ impl Default for InjectConfig {
 pub fn build_injection(config: &InjectConfig) -> String {
     let mut parts: Vec<&str> = config.presets.iter().map(|p| p.text()).collect();
     if let Some(ref custom) = config.custom_text
-        && !custom.is_empty() {
-            parts.push(custom);
-        }
+        && !custom.is_empty()
+    {
+        parts.push(custom);
+    }
     parts.join("\n\n")
 }
 

--- a/server/src/proxy/inject.rs
+++ b/server/src/proxy/inject.rs
@@ -107,11 +107,10 @@ impl Default for InjectConfig {
 /// Build the full injection text from active presets + custom text.
 pub fn build_injection(config: &InjectConfig) -> String {
     let mut parts: Vec<&str> = config.presets.iter().map(|p| p.text()).collect();
-    if let Some(ref custom) = config.custom_text {
-        if !custom.is_empty() {
+    if let Some(ref custom) = config.custom_text
+        && !custom.is_empty() {
             parts.push(custom);
         }
-    }
     parts.join("\n\n")
 }
 

--- a/server/src/proxy/inject.rs
+++ b/server/src/proxy/inject.rs
@@ -5,7 +5,7 @@
 
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
-use tracing::debug;
+// tracing used by inject_into_body callers, not here directly
 
 /// Available injection presets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]

--- a/server/src/proxy/keys.rs
+++ b/server/src/proxy/keys.rs
@@ -174,16 +174,14 @@ impl KeyStore {
         if let Some(mut entry) = self.keys.get_mut(key_id) {
             for (name, value) in headers {
                 let name_lower = name.to_lowercase();
-                if name_lower.contains("ratelimit") && name_lower.contains("5h") {
-                    if let Ok(v) = value.parse::<f64>() {
+                if name_lower.contains("ratelimit") && name_lower.contains("5h")
+                    && let Ok(v) = value.parse::<f64>() {
                         entry.rate_limit_5h = v;
                     }
-                }
-                if name_lower.contains("ratelimit") && name_lower.contains("7d") {
-                    if let Ok(v) = value.parse::<f64>() {
+                if name_lower.contains("ratelimit") && name_lower.contains("7d")
+                    && let Ok(v) = value.parse::<f64>() {
                         entry.rate_limit_7d = v;
                     }
-                }
             }
         }
     }

--- a/server/src/proxy/keys.rs
+++ b/server/src/proxy/keys.rs
@@ -8,8 +8,7 @@ use ring::aead;
 use ring::rand::{SecureRandom, SystemRandom};
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Instant;
-use tracing::{debug, info, warn};
+use tracing::warn;
 
 /// An API key entry in the key store.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/server/src/proxy/keys.rs
+++ b/server/src/proxy/keys.rs
@@ -174,14 +174,18 @@ impl KeyStore {
         if let Some(mut entry) = self.keys.get_mut(key_id) {
             for (name, value) in headers {
                 let name_lower = name.to_lowercase();
-                if name_lower.contains("ratelimit") && name_lower.contains("5h")
-                    && let Ok(v) = value.parse::<f64>() {
-                        entry.rate_limit_5h = v;
-                    }
-                if name_lower.contains("ratelimit") && name_lower.contains("7d")
-                    && let Ok(v) = value.parse::<f64>() {
-                        entry.rate_limit_7d = v;
-                    }
+                if name_lower.contains("ratelimit")
+                    && name_lower.contains("5h")
+                    && let Ok(v) = value.parse::<f64>()
+                {
+                    entry.rate_limit_5h = v;
+                }
+                if name_lower.contains("ratelimit")
+                    && name_lower.contains("7d")
+                    && let Ok(v) = value.parse::<f64>()
+                {
+                    entry.rate_limit_7d = v;
+                }
             }
         }
     }

--- a/server/src/proxy/keys.rs
+++ b/server/src/proxy/keys.rs
@@ -1,0 +1,317 @@
+//! API key rotation — round-robin/least-used key selection with rate-limit tracking.
+//!
+//! Keys are encrypted at rest using AES-256-GCM with a key derived from /etc/machine-id.
+//! Rate limits are tracked from response headers and auto-switch happens on 429.
+
+use dashmap::DashMap;
+use ring::aead;
+use ring::rand::{SecureRandom, SystemRandom};
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+use tracing::{debug, info, warn};
+
+/// An API key entry in the key store.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiKeyEntry {
+    pub id: String,
+    pub provider: String,
+    /// Base64-encoded encrypted key (AES-256-GCM)
+    pub key_encrypted: String,
+    pub label: String,
+    /// Percentage utilization of 5-hour rate limit (0-100)
+    pub rate_limit_5h: f64,
+    /// Percentage utilization of 7-day rate limit (0-100)
+    pub rate_limit_7d: f64,
+    pub last_used: Option<i64>,
+    pub active: bool,
+    /// Number of requests made with this key
+    pub request_count: u64,
+}
+
+/// Derive an AES-256 key from /etc/machine-id using HKDF.
+fn derive_key() -> aead::LessSafeKey {
+    let machine_id = std::fs::read_to_string("/etc/machine-id")
+        .unwrap_or_else(|_| "noaide-default-machine-id-fallback".to_string());
+    let salt = ring::hkdf::Salt::new(ring::hkdf::HKDF_SHA256, b"noaide-key-encryption");
+    let prk = salt.extract(machine_id.trim().as_bytes());
+    let okm = prk
+        .expand(&[b"noaide-api-keys-v1"], &aead::AES_256_GCM)
+        .expect("HKDF expand failed");
+    let mut key_bytes = [0u8; 32];
+    okm.fill(&mut key_bytes).expect("HKDF fill failed");
+    let unbound_key =
+        aead::UnboundKey::new(&aead::AES_256_GCM, &key_bytes).expect("AES key creation failed");
+    aead::LessSafeKey::new(unbound_key)
+}
+
+/// Encrypt an API key string.
+pub fn encrypt_key(plaintext: &str) -> String {
+    let key = derive_key();
+    let rng = SystemRandom::new();
+    let mut nonce_bytes = [0u8; 12];
+    rng.fill(&mut nonce_bytes).expect("RNG failed");
+    let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
+
+    let mut in_out = plaintext.as_bytes().to_vec();
+    key.seal_in_place_append_tag(nonce, aead::Aad::empty(), &mut in_out)
+        .expect("encryption failed");
+
+    // Prepend nonce to ciphertext
+    let mut result = nonce_bytes.to_vec();
+    result.extend_from_slice(&in_out);
+    base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &result)
+}
+
+/// Decrypt an API key string.
+pub fn decrypt_key(encrypted: &str) -> Result<String, String> {
+    let key = derive_key();
+    let data = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, encrypted)
+        .map_err(|e| format!("base64 decode error: {e}"))?;
+
+    if data.len() < 12 {
+        return Err("ciphertext too short".to_string());
+    }
+
+    let (nonce_bytes, ciphertext) = data.split_at(12);
+    let nonce = aead::Nonce::assume_unique_for_key(
+        nonce_bytes
+            .try_into()
+            .map_err(|_| "invalid nonce".to_string())?,
+    );
+
+    let mut in_out = ciphertext.to_vec();
+    let plaintext = key
+        .open_in_place(nonce, aead::Aad::empty(), &mut in_out)
+        .map_err(|_| "decryption failed".to_string())?;
+
+    String::from_utf8(plaintext.to_vec()).map_err(|e| format!("UTF-8 error: {e}"))
+}
+
+/// Key store with round-robin selection and rate-limit tracking.
+pub struct KeyStore {
+    keys: DashMap<String, ApiKeyEntry>,
+    /// Round-robin counter
+    counter: AtomicU64,
+}
+
+impl KeyStore {
+    pub fn new() -> Self {
+        Self {
+            keys: DashMap::new(),
+            counter: AtomicU64::new(0),
+        }
+    }
+
+    /// Add a key (encrypts the plaintext key).
+    pub fn add_key(&self, provider: &str, plaintext_key: &str, label: &str) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        let encrypted = encrypt_key(plaintext_key);
+        let entry = ApiKeyEntry {
+            id: id.clone(),
+            provider: provider.to_string(),
+            key_encrypted: encrypted,
+            label: label.to_string(),
+            rate_limit_5h: 0.0,
+            rate_limit_7d: 0.0,
+            last_used: None,
+            active: true,
+            request_count: 0,
+        };
+        self.keys.insert(id.clone(), entry);
+        id
+    }
+
+    /// Remove a key by ID.
+    pub fn remove_key(&self, id: &str) -> bool {
+        self.keys.remove(id).is_some()
+    }
+
+    /// Get all keys (without decrypted values).
+    pub fn list_keys(&self) -> Vec<ApiKeyEntry> {
+        self.keys.iter().map(|r| r.value().clone()).collect()
+    }
+
+    /// Select the next active key for a provider using round-robin.
+    /// Returns (key_id, decrypted_key) or None if no active keys.
+    pub fn select_key(&self, provider: &str) -> Option<(String, String)> {
+        let active: Vec<_> = self
+            .keys
+            .iter()
+            .filter(|r| r.value().provider == provider && r.value().active)
+            .map(|r| (r.key().clone(), r.value().key_encrypted.clone()))
+            .collect();
+
+        if active.is_empty() {
+            return None;
+        }
+
+        let idx = self.counter.fetch_add(1, Ordering::Relaxed) as usize % active.len();
+        let (id, encrypted) = &active[idx];
+
+        match decrypt_key(encrypted) {
+            Ok(plaintext) => {
+                // Update usage stats
+                if let Some(mut entry) = self.keys.get_mut(id) {
+                    entry.last_used = Some(
+                        std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_millis() as i64,
+                    );
+                    entry.request_count += 1;
+                }
+                Some((id.clone(), plaintext))
+            }
+            Err(e) => {
+                warn!(key_id = %id, error = %e, "failed to decrypt API key");
+                None
+            }
+        }
+    }
+
+    /// Update rate-limit info from response headers.
+    pub fn update_rate_limits(&self, key_id: &str, headers: &[(String, String)]) {
+        if let Some(mut entry) = self.keys.get_mut(key_id) {
+            for (name, value) in headers {
+                let name_lower = name.to_lowercase();
+                if name_lower.contains("ratelimit") && name_lower.contains("5h") {
+                    if let Ok(v) = value.parse::<f64>() {
+                        entry.rate_limit_5h = v;
+                    }
+                }
+                if name_lower.contains("ratelimit") && name_lower.contains("7d") {
+                    if let Ok(v) = value.parse::<f64>() {
+                        entry.rate_limit_7d = v;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Mark a key as inactive (e.g., after repeated 429s).
+    pub fn deactivate_key(&self, key_id: &str) {
+        if let Some(mut entry) = self.keys.get_mut(key_id) {
+            entry.active = false;
+            warn!(key_id = %key_id, label = %entry.label, "deactivated API key due to rate limiting");
+        }
+    }
+
+    /// Check if the store has any active keys for a provider.
+    pub fn has_active_keys(&self, provider: &str) -> bool {
+        self.keys
+            .iter()
+            .any(|r| r.value().provider == provider && r.value().active)
+    }
+
+    /// Get status summary for all keys.
+    pub fn status(&self) -> Vec<serde_json::Value> {
+        self.keys
+            .iter()
+            .map(|r| {
+                let v = r.value();
+                serde_json::json!({
+                    "id": v.id,
+                    "provider": v.provider,
+                    "label": v.label,
+                    "active": v.active,
+                    "rate_limit_5h": v.rate_limit_5h,
+                    "rate_limit_7d": v.rate_limit_7d,
+                    "last_used": v.last_used,
+                    "request_count": v.request_count,
+                })
+            })
+            .collect()
+    }
+}
+
+impl Default for KeyStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encrypt_decrypt_roundtrip() {
+        let key = "sk-ant-api03-test-key-1234567890";
+        let encrypted = encrypt_key(key);
+        assert_ne!(encrypted, key);
+        let decrypted = decrypt_key(&encrypted).unwrap();
+        assert_eq!(decrypted, key);
+    }
+
+    #[test]
+    fn add_and_select_key() {
+        let store = KeyStore::new();
+        let id = store.add_key("anthropic", "sk-test-key", "Test Key");
+        assert!(!id.is_empty());
+
+        let result = store.select_key("anthropic");
+        assert!(result.is_some());
+        let (selected_id, plaintext) = result.unwrap();
+        assert_eq!(selected_id, id);
+        assert_eq!(plaintext, "sk-test-key");
+    }
+
+    #[test]
+    fn round_robin_distribution() {
+        let store = KeyStore::new();
+        store.add_key("anthropic", "key-1", "Key 1");
+        store.add_key("anthropic", "key-2", "Key 2");
+
+        let mut keys_used = std::collections::HashSet::new();
+        for _ in 0..10 {
+            if let Some((_, key)) = store.select_key("anthropic") {
+                keys_used.insert(key);
+            }
+        }
+        // Both keys should have been used
+        assert_eq!(keys_used.len(), 2);
+    }
+
+    #[test]
+    fn deactivate_key_excluded() {
+        let store = KeyStore::new();
+        let id1 = store.add_key("anthropic", "key-1", "Key 1");
+        store.add_key("anthropic", "key-2", "Key 2");
+
+        store.deactivate_key(&id1);
+
+        // Only key-2 should be selectable
+        for _ in 0..5 {
+            let (_, key) = store.select_key("anthropic").unwrap();
+            assert_eq!(key, "key-2");
+        }
+    }
+
+    #[test]
+    fn no_keys_returns_none() {
+        let store = KeyStore::new();
+        assert!(store.select_key("anthropic").is_none());
+    }
+
+    #[test]
+    fn remove_key() {
+        let store = KeyStore::new();
+        let id = store.add_key("anthropic", "key-1", "Key 1");
+        assert!(store.remove_key(&id));
+        assert!(store.select_key("anthropic").is_none());
+    }
+
+    #[test]
+    fn provider_isolation() {
+        let store = KeyStore::new();
+        store.add_key("anthropic", "key-ant", "Ant Key");
+        store.add_key("openai", "key-oai", "OAI Key");
+
+        let (_, key) = store.select_key("anthropic").unwrap();
+        assert_eq!(key, "key-ant");
+
+        let (_, key) = store.select_key("openai").unwrap();
+        assert_eq!(key, "key-oai");
+    }
+}

--- a/server/src/proxy/mitm.rs
+++ b/server/src/proxy/mitm.rs
@@ -90,7 +90,18 @@ pub fn build_log(
             .as_millis() as i64,
         request_size: request_body.len(),
         response_size: response_body.len(),
-        category: None,
+        category: {
+            // Classify reverse-proxy requests by extracting host from URL
+            let host = url
+                .strip_prefix("https://")
+                .or_else(|| url.strip_prefix("http://"))
+                .unwrap_or(url)
+                .split('/')
+                .next()
+                .unwrap_or("");
+            let cat = super::classify::classify_domain(host);
+            Some(cat.to_string())
+        },
     }
 }
 

--- a/server/src/proxy/mod.rs
+++ b/server/src/proxy/mod.rs
@@ -1,5 +1,6 @@
 pub mod classify;
 pub mod handler;
+pub mod inject;
 pub mod mitm;
 pub mod modes;
 pub mod rules;
@@ -75,6 +76,7 @@ pub fn create_proxy_state() -> (Arc<ProxyState>, broadcast::Receiver<ApiRequestL
         ca,
         network_rules: Arc::new(rules::NetworkRulesEngine::new()),
         proxy_modes: modes::ProxyModeStore::new(),
+        inject_store: inject::InjectStore::new(),
     });
 
     (state, event_rx)

--- a/server/src/proxy/mod.rs
+++ b/server/src/proxy/mod.rs
@@ -1,3 +1,4 @@
+pub mod audit;
 pub mod classify;
 pub mod handler;
 pub mod inject;

--- a/server/src/proxy/mod.rs
+++ b/server/src/proxy/mod.rs
@@ -1,6 +1,7 @@
 pub mod classify;
 pub mod handler;
 pub mod mitm;
+pub mod modes;
 pub mod rules;
 pub mod tls_mitm;
 pub mod websocket;
@@ -73,6 +74,7 @@ pub fn create_proxy_state() -> (Arc<ProxyState>, broadcast::Receiver<ApiRequestL
         pending_images: RwLock::new(HashMap::new()),
         ca,
         network_rules: Arc::new(rules::NetworkRulesEngine::new()),
+        proxy_modes: modes::ProxyModeStore::new(),
     });
 
     (state, event_rx)

--- a/server/src/proxy/mod.rs
+++ b/server/src/proxy/mod.rs
@@ -1,6 +1,7 @@
 pub mod classify;
 pub mod handler;
 pub mod inject;
+pub mod keys;
 pub mod mitm;
 pub mod modes;
 pub mod persist;
@@ -80,6 +81,7 @@ pub fn create_proxy_state() -> (Arc<ProxyState>, broadcast::Receiver<ApiRequestL
         proxy_modes: modes::ProxyModeStore::new(),
         inject_store: inject::InjectStore::new(),
         rewrite_store: rewrite::RewriteStore::new(),
+        key_store: keys::KeyStore::new(),
     });
 
     (state, event_rx)

--- a/server/src/proxy/mod.rs
+++ b/server/src/proxy/mod.rs
@@ -3,6 +3,7 @@ pub mod handler;
 pub mod inject;
 pub mod mitm;
 pub mod modes;
+pub mod persist;
 pub mod rewrite;
 pub mod rules;
 pub mod tls_mitm;

--- a/server/src/proxy/mod.rs
+++ b/server/src/proxy/mod.rs
@@ -3,6 +3,7 @@ pub mod handler;
 pub mod inject;
 pub mod mitm;
 pub mod modes;
+pub mod rewrite;
 pub mod rules;
 pub mod tls_mitm;
 pub mod websocket;
@@ -77,6 +78,7 @@ pub fn create_proxy_state() -> (Arc<ProxyState>, broadcast::Receiver<ApiRequestL
         network_rules: Arc::new(rules::NetworkRulesEngine::new()),
         proxy_modes: modes::ProxyModeStore::new(),
         inject_store: inject::InjectStore::new(),
+        rewrite_store: rewrite::RewriteStore::new(),
     });
 
     (state, event_rx)

--- a/server/src/proxy/mod.rs
+++ b/server/src/proxy/mod.rs
@@ -3,6 +3,7 @@ pub mod handler;
 pub mod mitm;
 pub mod rules;
 pub mod tls_mitm;
+pub mod websocket;
 
 use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;

--- a/server/src/proxy/modes.rs
+++ b/server/src/proxy/modes.rs
@@ -13,8 +13,10 @@ use serde::{Deserialize, Serialize};
 /// Proxy operation mode for a session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[derive(Default)]
 pub enum ProxyMode {
     /// Default: allow all traffic, no interception
+    #[default]
     Auto,
     /// Intercept all requests for manual review
     Manual,
@@ -26,11 +28,6 @@ pub enum ProxyMode {
     Lockdown,
 }
 
-impl Default for ProxyMode {
-    fn default() -> Self {
-        ProxyMode::Auto
-    }
-}
 
 /// Per-session proxy mode storage.
 pub struct ProxyModeStore {

--- a/server/src/proxy/modes.rs
+++ b/server/src/proxy/modes.rs
@@ -28,7 +28,6 @@ pub enum ProxyMode {
     Lockdown,
 }
 
-
 /// Per-session proxy mode storage.
 pub struct ProxyModeStore {
     modes: DashMap<String, ProxyMode>,

--- a/server/src/proxy/modes.rs
+++ b/server/src/proxy/modes.rs
@@ -1,0 +1,140 @@
+//! Proxy mode presets — 5 modes that configure per-session proxy behavior.
+//!
+//! Each mode applies a set of default rules and behaviors:
+//! - Auto: Default allow, no special rules
+//! - Manual: Intercept all requests for manual review
+//! - Custom: User-defined rules, no auto-changes
+//! - Pure: Block telemetry + strip non-essential fields
+//! - Lockdown: Block everything except Api category
+
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+
+/// Proxy operation mode for a session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProxyMode {
+    /// Default: allow all traffic, no interception
+    Auto,
+    /// Intercept all requests for manual review
+    Manual,
+    /// User-defined rules only, no automatic changes
+    Custom,
+    /// Block telemetry, strip non-essential request fields
+    Pure,
+    /// Block everything except Api-category traffic
+    Lockdown,
+}
+
+impl Default for ProxyMode {
+    fn default() -> Self {
+        ProxyMode::Auto
+    }
+}
+
+/// Per-session proxy mode storage.
+pub struct ProxyModeStore {
+    modes: DashMap<String, ProxyMode>,
+}
+
+impl ProxyModeStore {
+    pub fn new() -> Self {
+        Self {
+            modes: DashMap::new(),
+        }
+    }
+
+    pub fn get(&self, session_id: &str) -> ProxyMode {
+        self.modes
+            .get(session_id)
+            .map(|r| *r.value())
+            .unwrap_or_default()
+    }
+
+    pub fn set(&self, session_id: String, mode: ProxyMode) {
+        self.modes.insert(session_id, mode);
+    }
+
+    /// Check if a request should be blocked based on the current mode and category.
+    pub fn should_block(&self, session_id: &str, category: &str) -> bool {
+        let mode = self.get(session_id);
+        match mode {
+            ProxyMode::Lockdown => category != "Api",
+            ProxyMode::Pure => category == "Telemetry",
+            _ => false,
+        }
+    }
+
+    /// Check if session is in Manual intercept mode.
+    pub fn is_manual(&self, session_id: &str) -> bool {
+        self.get(session_id) == ProxyMode::Manual
+    }
+}
+
+impl Default for ProxyModeStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_mode_is_auto() {
+        let store = ProxyModeStore::new();
+        assert_eq!(store.get("unknown-session"), ProxyMode::Auto);
+    }
+
+    #[test]
+    fn set_and_get_mode() {
+        let store = ProxyModeStore::new();
+        store.set("session-1".to_string(), ProxyMode::Lockdown);
+        assert_eq!(store.get("session-1"), ProxyMode::Lockdown);
+    }
+
+    #[test]
+    fn lockdown_blocks_non_api() {
+        let store = ProxyModeStore::new();
+        store.set("s1".to_string(), ProxyMode::Lockdown);
+        assert!(store.should_block("s1", "Telemetry"));
+        assert!(store.should_block("s1", "Update"));
+        assert!(store.should_block("s1", "Auth"));
+        assert!(!store.should_block("s1", "Api"));
+    }
+
+    #[test]
+    fn pure_blocks_telemetry_only() {
+        let store = ProxyModeStore::new();
+        store.set("s1".to_string(), ProxyMode::Pure);
+        assert!(store.should_block("s1", "Telemetry"));
+        assert!(!store.should_block("s1", "Api"));
+        assert!(!store.should_block("s1", "Auth"));
+        assert!(!store.should_block("s1", "Update"));
+    }
+
+    #[test]
+    fn auto_blocks_nothing() {
+        let store = ProxyModeStore::new();
+        store.set("s1".to_string(), ProxyMode::Auto);
+        assert!(!store.should_block("s1", "Telemetry"));
+        assert!(!store.should_block("s1", "Api"));
+    }
+
+    #[test]
+    fn manual_mode_detected() {
+        let store = ProxyModeStore::new();
+        store.set("s1".to_string(), ProxyMode::Manual);
+        assert!(store.is_manual("s1"));
+        assert!(!store.is_manual("s2"));
+    }
+
+    #[test]
+    fn mode_serde_roundtrip() {
+        let json = serde_json::to_string(&ProxyMode::Lockdown).unwrap();
+        assert_eq!(json, "\"lockdown\"");
+        let parsed: ProxyMode = serde_json::from_str("\"pure\"").unwrap();
+        assert_eq!(parsed, ProxyMode::Pure);
+    }
+}

--- a/server/src/proxy/persist.rs
+++ b/server/src/proxy/persist.rs
@@ -144,7 +144,12 @@ mod tests {
     use std::fs;
 
     fn test_dir() -> PathBuf {
-        let dir = std::env::temp_dir().join(format!("noaide-persist-test-{}", std::process::id()));
+        let id = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("noaide-persist-test-{id}"));
+        let _ = fs::remove_dir_all(&dir); // clean up leftover from previous run
         fs::create_dir_all(&dir).unwrap();
         dir
     }

--- a/server/src/proxy/persist.rs
+++ b/server/src/proxy/persist.rs
@@ -174,9 +174,13 @@ mod tests {
         let json = serde_json::to_string_pretty(&config).unwrap();
         fs::write(&path, &json).unwrap();
 
-        let loaded: ProxyConfig = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let loaded: ProxyConfig =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(loaded.mode, super::super::modes::ProxyMode::Pure);
-        assert_eq!(loaded.rewrite.model_override, Some("claude-sonnet-4-6".to_string()));
+        assert_eq!(
+            loaded.rewrite.model_override,
+            Some("claude-sonnet-4-6".to_string())
+        );
 
         fs::remove_dir_all(&dir).unwrap();
     }

--- a/server/src/proxy/persist.rs
+++ b/server/src/proxy/persist.rs
@@ -1,0 +1,221 @@
+//! Config persistence — save/load per-session proxy configuration to disk.
+//!
+//! Saves proxy config (rules, mode, inject, rewrite) as JSON files in /data/noaide/.
+//! Debounced save (1s after last change), 30-day TTL cleanup on startup.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use tracing::{debug, info, warn};
+
+/// Combined proxy configuration for a session.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ProxyConfig {
+    pub mode: super::modes::ProxyMode,
+    pub inject: super::inject::InjectConfig,
+    pub rewrite: super::rewrite::RewriteConfig,
+}
+
+/// Config directory for proxy persistence.
+fn config_dir() -> PathBuf {
+    PathBuf::from("/data/noaide")
+}
+
+/// Config file path for a session.
+fn config_path(session_id: &str) -> PathBuf {
+    config_dir().join(format!("proxy-config-{session_id}.json"))
+}
+
+/// Save proxy config for a session to disk.
+pub fn save_config(session_id: &str, config: &ProxyConfig) -> Result<(), std::io::Error> {
+    let dir = config_dir();
+    std::fs::create_dir_all(&dir)?;
+    let path = config_path(session_id);
+    let json = serde_json::to_string_pretty(config)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    std::fs::write(&path, json)?;
+    debug!(session_id = %session_id, path = %path.display(), "saved proxy config");
+    Ok(())
+}
+
+/// Load proxy config for a session from disk.
+pub fn load_config(session_id: &str) -> Option<ProxyConfig> {
+    let path = config_path(session_id);
+    match std::fs::read_to_string(&path) {
+        Ok(json) => match serde_json::from_str(&json) {
+            Ok(config) => {
+                debug!(session_id = %session_id, "loaded proxy config from disk");
+                Some(config)
+            }
+            Err(e) => {
+                warn!(session_id = %session_id, error = %e, "failed to parse proxy config");
+                None
+            }
+        },
+        Err(_) => None,
+    }
+}
+
+/// Clean up config files older than `max_age` from the config directory.
+///
+/// Returns the number of files deleted.
+pub fn cleanup_old_configs(max_age: std::time::Duration) -> usize {
+    let dir = config_dir();
+    let mut deleted = 0;
+
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+
+    let now = std::time::SystemTime::now();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with("proxy-config-") && n.ends_with(".json"))
+        {
+            continue;
+        }
+
+        if let Ok(metadata) = path.metadata() {
+            if let Ok(modified) = metadata.modified() {
+                if let Ok(age) = now.duration_since(modified) {
+                    if age > max_age {
+                        if std::fs::remove_file(&path).is_ok() {
+                            info!(path = %path.display(), age_days = age.as_secs() / 86400, "deleted old proxy config");
+                            deleted += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    deleted
+}
+
+/// List all session IDs that have saved configs.
+pub fn list_saved_sessions() -> Vec<String> {
+    let dir = config_dir();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return vec![],
+    };
+
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.file_name().to_str()?.to_string();
+            name.strip_prefix("proxy-config-")?
+                .strip_suffix(".json")
+                .map(|s| s.to_string())
+        })
+        .collect()
+}
+
+/// Schedule a debounced save (1s after last change).
+///
+/// Call this after any config mutation. Uses a simple fire-and-forget approach:
+/// spawns a tokio task that waits 1s then saves. Repeated calls within 1s
+/// result in multiple saves (last one wins), which is acceptable for this use case.
+pub fn schedule_save(session_id: String, config: ProxyConfig) {
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        if let Err(e) = save_config(&session_id, &config) {
+            warn!(session_id = %session_id, error = %e, "failed to persist proxy config");
+        }
+    });
+}
+
+/// Run cleanup of configs older than 30 days. Call at server startup.
+pub fn startup_cleanup() {
+    let max_age = std::time::Duration::from_secs(30 * 24 * 3600); // 30 days
+    let deleted = cleanup_old_configs(max_age);
+    if deleted > 0 {
+        info!(deleted = deleted, "cleaned up old proxy configs");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn test_dir() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("noaide-persist-test-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn save_and_load_config() {
+        let dir = test_dir();
+        let path = dir.join("proxy-config-test-session.json");
+
+        let config = ProxyConfig {
+            mode: super::super::modes::ProxyMode::Pure,
+            inject: super::super::inject::InjectConfig {
+                presets: vec![super::super::inject::Preset::AntiLaziness],
+                custom_text: Some("custom".to_string()),
+            },
+            rewrite: super::super::rewrite::RewriteConfig {
+                model_override: Some("claude-sonnet-4-6".to_string()),
+                ..Default::default()
+            },
+        };
+
+        let json = serde_json::to_string_pretty(&config).unwrap();
+        fs::write(&path, &json).unwrap();
+
+        let loaded: ProxyConfig = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(loaded.mode, super::super::modes::ProxyMode::Pure);
+        assert_eq!(loaded.rewrite.model_override, Some("claude-sonnet-4-6".to_string()));
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn config_serde_roundtrip() {
+        let config = ProxyConfig::default();
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: ProxyConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.mode, super::super::modes::ProxyMode::Auto);
+    }
+
+    #[test]
+    fn cleanup_old_files() {
+        let dir = test_dir();
+        // Create a "config" file
+        let path = dir.join("proxy-config-old-session.json");
+        fs::write(&path, "{}").unwrap();
+
+        // File is fresh — should NOT be deleted with 0s max age
+        // (We can't easily backdate files in a test, so test the path parsing)
+        let entries: Vec<_> = fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .is_some_and(|n| n.starts_with("proxy-config-") && n.ends_with(".json"))
+            })
+            .collect();
+        assert_eq!(entries.len(), 1);
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn list_saved_sessions_parses_filenames() {
+        // This tests the filename parsing logic
+        let name = "proxy-config-abc-123.json";
+        let session_id = name
+            .strip_prefix("proxy-config-")
+            .unwrap()
+            .strip_suffix(".json")
+            .unwrap();
+        assert_eq!(session_id, "abc-123");
+    }
+}

--- a/server/src/proxy/persist.rs
+++ b/server/src/proxy/persist.rs
@@ -81,12 +81,13 @@ pub fn cleanup_old_configs(max_age: std::time::Duration) -> usize {
 
         if let Ok(metadata) = path.metadata()
             && let Ok(modified) = metadata.modified()
-                && let Ok(age) = now.duration_since(modified)
-                    && age > max_age
-                        && std::fs::remove_file(&path).is_ok() {
-                            info!(path = %path.display(), age_days = age.as_secs() / 86400, "deleted old proxy config");
-                            deleted += 1;
-                        }
+            && let Ok(age) = now.duration_since(modified)
+            && age > max_age
+            && std::fs::remove_file(&path).is_ok()
+        {
+            info!(path = %path.display(), age_days = age.as_secs() / 86400, "deleted old proxy config");
+            deleted += 1;
+        }
     }
 
     deleted

--- a/server/src/proxy/persist.rs
+++ b/server/src/proxy/persist.rs
@@ -79,18 +79,14 @@ pub fn cleanup_old_configs(max_age: std::time::Duration) -> usize {
             continue;
         }
 
-        if let Ok(metadata) = path.metadata() {
-            if let Ok(modified) = metadata.modified() {
-                if let Ok(age) = now.duration_since(modified) {
-                    if age > max_age {
-                        if std::fs::remove_file(&path).is_ok() {
+        if let Ok(metadata) = path.metadata()
+            && let Ok(modified) = metadata.modified()
+                && let Ok(age) = now.duration_since(modified)
+                    && age > max_age
+                        && std::fs::remove_file(&path).is_ok() {
                             info!(path = %path.display(), age_days = age.as_secs() / 86400, "deleted old proxy config");
                             deleted += 1;
                         }
-                    }
-                }
-            }
-        }
     }
 
     deleted

--- a/server/src/proxy/rewrite.rs
+++ b/server/src/proxy/rewrite.rs
@@ -109,13 +109,14 @@ pub fn apply_rewrites(
 
     // Thinking type override (Anthropic only)
     if let Some(ref thinking) = config.thinking_type
-        && provider == ApiProvider::Anthropic {
-            if body.get("thinking").is_none() {
-                body["thinking"] = serde_json::json!({});
-            }
-            body["thinking"]["type"] = serde_json::Value::String(thinking.clone());
-            modified = true;
+        && provider == ApiProvider::Anthropic
+    {
+        if body.get("thinking").is_none() {
+            body["thinking"] = serde_json::json!({});
         }
+        body["thinking"]["type"] = serde_json::Value::String(thinking.clone());
+        modified = true;
+    }
 
     if modified {
         debug!(provider = %provider.label(), "applied request body rewrites");

--- a/server/src/proxy/rewrite.rs
+++ b/server/src/proxy/rewrite.rs
@@ -1,0 +1,303 @@
+//! Request body rewriting — model override, parameter tweaks, and pure mode.
+//!
+//! Apply per-session rewrites to API request bodies before forwarding to upstream.
+//! Supports model override, temperature, max tokens, thinking type, and pure mode
+//! (strip everything except model + messages + stream).
+
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+/// Per-session rewrite configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RewriteConfig {
+    /// Override the model name in the request
+    pub model_override: Option<String>,
+    /// Override temperature
+    pub temperature: Option<f64>,
+    /// Override max tokens
+    pub max_tokens: Option<u64>,
+    /// Override thinking type (for Anthropic extended thinking)
+    pub thinking_type: Option<String>,
+    /// Pure mode: strip everything except model + messages + stream
+    pub pure_mode: bool,
+}
+
+impl RewriteConfig {
+    pub fn is_active(&self) -> bool {
+        self.model_override.is_some()
+            || self.temperature.is_some()
+            || self.max_tokens.is_some()
+            || self.thinking_type.is_some()
+            || self.pure_mode
+    }
+}
+
+/// Apply rewrites to an API request body.
+///
+/// Returns `true` if any modifications were made.
+pub fn apply_rewrites(
+    body: &mut serde_json::Value,
+    provider: super::handler::ApiProvider,
+    config: &RewriteConfig,
+) -> bool {
+    use super::handler::ApiProvider;
+
+    if !config.is_active() {
+        return false;
+    }
+
+    let mut modified = false;
+
+    // Pure mode: strip to essentials first
+    if config.pure_mode {
+        strip_to_essentials(body, provider);
+        modified = true;
+    }
+
+    // Model override
+    if let Some(ref model) = config.model_override {
+        match provider {
+            ApiProvider::Anthropic | ApiProvider::OpenAI | ApiProvider::ChatGPT => {
+                body["model"] = serde_json::Value::String(model.clone());
+                modified = true;
+            }
+            ApiProvider::Google | ApiProvider::GoogleCodeAssist => {
+                body["model"] = serde_json::Value::String(model.clone());
+                modified = true;
+            }
+        }
+    }
+
+    // Temperature override
+    if let Some(temp) = config.temperature {
+        match provider {
+            ApiProvider::Anthropic | ApiProvider::OpenAI | ApiProvider::ChatGPT => {
+                body["temperature"] = serde_json::json!(temp);
+                modified = true;
+            }
+            ApiProvider::Google | ApiProvider::GoogleCodeAssist => {
+                if body.get("generationConfig").is_none() {
+                    body["generationConfig"] = serde_json::json!({});
+                }
+                body["generationConfig"]["temperature"] = serde_json::json!(temp);
+                modified = true;
+            }
+        }
+    }
+
+    // Max tokens override
+    if let Some(max) = config.max_tokens {
+        match provider {
+            ApiProvider::Anthropic => {
+                body["max_tokens"] = serde_json::json!(max);
+                modified = true;
+            }
+            ApiProvider::OpenAI | ApiProvider::ChatGPT => {
+                body["max_output_tokens"] = serde_json::json!(max);
+                modified = true;
+            }
+            ApiProvider::Google | ApiProvider::GoogleCodeAssist => {
+                if body.get("generationConfig").is_none() {
+                    body["generationConfig"] = serde_json::json!({});
+                }
+                body["generationConfig"]["maxOutputTokens"] = serde_json::json!(max);
+                modified = true;
+            }
+        }
+    }
+
+    // Thinking type override (Anthropic only)
+    if let Some(ref thinking) = config.thinking_type {
+        if provider == ApiProvider::Anthropic {
+            if body.get("thinking").is_none() {
+                body["thinking"] = serde_json::json!({});
+            }
+            body["thinking"]["type"] = serde_json::Value::String(thinking.clone());
+            modified = true;
+        }
+    }
+
+    if modified {
+        debug!(provider = %provider.label(), "applied request body rewrites");
+    }
+
+    modified
+}
+
+/// Strip request body to essential fields only (pure mode).
+///
+/// Keeps only: model, messages/contents/input, stream
+fn strip_to_essentials(body: &mut serde_json::Value, provider: super::handler::ApiProvider) {
+    use super::handler::ApiProvider;
+
+    let obj = match body.as_object_mut() {
+        Some(o) => o,
+        None => return,
+    };
+
+    let essential_keys: &[&str] = match provider {
+        ApiProvider::Anthropic => &["model", "messages", "stream", "max_tokens"],
+        ApiProvider::OpenAI | ApiProvider::ChatGPT => {
+            &["model", "messages", "input", "stream", "max_output_tokens"]
+        }
+        ApiProvider::Google | ApiProvider::GoogleCodeAssist => {
+            &["model", "contents", "stream", "generationConfig"]
+        }
+    };
+
+    obj.retain(|key, _| essential_keys.contains(&key.as_str()));
+}
+
+/// Per-session rewrite config storage.
+pub struct RewriteStore {
+    configs: DashMap<String, RewriteConfig>,
+}
+
+impl RewriteStore {
+    pub fn new() -> Self {
+        Self {
+            configs: DashMap::new(),
+        }
+    }
+
+    pub fn get(&self, session_id: &str) -> RewriteConfig {
+        self.configs
+            .get(session_id)
+            .map(|r| r.value().clone())
+            .unwrap_or_default()
+    }
+
+    pub fn set(&self, session_id: String, config: RewriteConfig) {
+        self.configs.insert(session_id, config);
+    }
+}
+
+impl Default for RewriteStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::handler::ApiProvider;
+
+    #[test]
+    fn model_override_anthropic() {
+        let mut body = serde_json::json!({
+            "model": "claude-opus-4-6",
+            "messages": [],
+            "max_tokens": 4096
+        });
+        let config = RewriteConfig {
+            model_override: Some("claude-sonnet-4-6".to_string()),
+            ..Default::default()
+        };
+        let modified = apply_rewrites(&mut body, ApiProvider::Anthropic, &config);
+        assert!(modified);
+        assert_eq!(body["model"], "claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn model_override_openai() {
+        let mut body = serde_json::json!({
+            "model": "gpt-4",
+            "messages": []
+        });
+        let config = RewriteConfig {
+            model_override: Some("gpt-4o".to_string()),
+            ..Default::default()
+        };
+        let modified = apply_rewrites(&mut body, ApiProvider::OpenAI, &config);
+        assert!(modified);
+        assert_eq!(body["model"], "gpt-4o");
+    }
+
+    #[test]
+    fn temperature_override_google() {
+        let mut body = serde_json::json!({
+            "contents": []
+        });
+        let config = RewriteConfig {
+            temperature: Some(0.5),
+            ..Default::default()
+        };
+        let modified = apply_rewrites(&mut body, ApiProvider::Google, &config);
+        assert!(modified);
+        assert_eq!(body["generationConfig"]["temperature"], 0.5);
+    }
+
+    #[test]
+    fn pure_mode_strips_anthropic() {
+        let mut body = serde_json::json!({
+            "model": "claude-opus-4-6",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true,
+            "max_tokens": 4096,
+            "system": "be helpful",
+            "temperature": 0.7,
+            "metadata": {"user_id": "test"}
+        });
+        let config = RewriteConfig {
+            pure_mode: true,
+            ..Default::default()
+        };
+        let modified = apply_rewrites(&mut body, ApiProvider::Anthropic, &config);
+        assert!(modified);
+        assert!(body.get("model").is_some());
+        assert!(body.get("messages").is_some());
+        assert!(body.get("stream").is_some());
+        assert!(body.get("max_tokens").is_some());
+        assert!(body.get("system").is_none());
+        assert!(body.get("temperature").is_none());
+        assert!(body.get("metadata").is_none());
+    }
+
+    #[test]
+    fn pure_mode_strips_openai() {
+        let mut body = serde_json::json!({
+            "model": "gpt-4",
+            "messages": [],
+            "stream": true,
+            "temperature": 0.7,
+            "tools": [],
+            "tool_choice": "auto"
+        });
+        let config = RewriteConfig {
+            pure_mode: true,
+            ..Default::default()
+        };
+        let modified = apply_rewrites(&mut body, ApiProvider::OpenAI, &config);
+        assert!(modified);
+        assert!(body.get("model").is_some());
+        assert!(body.get("messages").is_some());
+        assert!(body.get("stream").is_some());
+        assert!(body.get("tools").is_none());
+        assert!(body.get("tool_choice").is_none());
+    }
+
+    #[test]
+    fn inactive_config_no_change() {
+        let mut body = serde_json::json!({"model": "test"});
+        let config = RewriteConfig::default();
+        let modified = apply_rewrites(&mut body, ApiProvider::Anthropic, &config);
+        assert!(!modified);
+    }
+
+    #[test]
+    fn config_serde_roundtrip() {
+        let config = RewriteConfig {
+            model_override: Some("claude-sonnet-4-6".to_string()),
+            temperature: Some(0.5),
+            max_tokens: Some(8192),
+            thinking_type: Some("enabled".to_string()),
+            pure_mode: true,
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: RewriteConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.model_override, config.model_override);
+        assert_eq!(parsed.pure_mode, true);
+    }
+}

--- a/server/src/proxy/rewrite.rs
+++ b/server/src/proxy/rewrite.rs
@@ -108,15 +108,14 @@ pub fn apply_rewrites(
     }
 
     // Thinking type override (Anthropic only)
-    if let Some(ref thinking) = config.thinking_type {
-        if provider == ApiProvider::Anthropic {
+    if let Some(ref thinking) = config.thinking_type
+        && provider == ApiProvider::Anthropic {
             if body.get("thinking").is_none() {
                 body["thinking"] = serde_json::json!({});
             }
             body["thinking"]["type"] = serde_json::Value::String(thinking.clone());
             modified = true;
         }
-    }
 
     if modified {
         debug!(provider = %provider.label(), "applied request body rewrites");
@@ -298,6 +297,6 @@ mod tests {
         let json = serde_json::to_string(&config).unwrap();
         let parsed: RewriteConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.model_override, config.model_override);
-        assert_eq!(parsed.pure_mode, true);
+        assert!(parsed.pure_mode);
     }
 }

--- a/server/src/proxy/rewrite.rs
+++ b/server/src/proxy/rewrite.rs
@@ -181,8 +181,8 @@ impl Default for RewriteStore {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::handler::ApiProvider;
+    use super::*;
 
     #[test]
     fn model_override_anthropic() {

--- a/server/src/proxy/websocket.rs
+++ b/server/src/proxy/websocket.rs
@@ -82,29 +82,17 @@ pub async fn relay_frames(
                     )
                     .await;
 
-                    if upstream_tx
-                        .send(TungMessage::Binary(data))
-                        .await
-                        .is_err()
-                    {
+                    if upstream_tx.send(TungMessage::Binary(data)).await.is_err() {
                         break;
                     }
                 }
                 axum::extract::ws::Message::Ping(data) => {
-                    if upstream_tx
-                        .send(TungMessage::Ping(data))
-                        .await
-                        .is_err()
-                    {
+                    if upstream_tx.send(TungMessage::Ping(data)).await.is_err() {
                         break;
                     }
                 }
                 axum::extract::ws::Message::Pong(data) => {
-                    if upstream_tx
-                        .send(TungMessage::Pong(data))
-                        .await
-                        .is_err()
-                    {
+                    if upstream_tx.send(TungMessage::Pong(data)).await.is_err() {
                         break;
                     }
                 }
@@ -344,8 +332,8 @@ mod tests {
 
     #[tokio::test]
     async fn log_ws_frame_text_redacts_keys() {
-        use tokio::sync::{RwLock, broadcast};
         use std::collections::{HashMap, VecDeque};
+        use tokio::sync::{RwLock, broadcast};
 
         let (event_tx, _rx) = broadcast::channel(16);
         let state = Arc::new(super::super::handler::ProxyState {
@@ -367,7 +355,15 @@ mod tests {
         let session = Some("test-session".to_string());
         let body_with_key = r#"{"key": "sk-ant-api03-secret123"}"#;
 
-        log_ws_frame(&session, "wss://example.com/ws", "WS-OUT", Some(body_with_key), body_with_key.len(), &state).await;
+        log_ws_frame(
+            &session,
+            "wss://example.com/ws",
+            "WS-OUT",
+            Some(body_with_key),
+            body_with_key.len(),
+            &state,
+        )
+        .await;
 
         let captured = state.captured.read().await;
         assert_eq!(captured.len(), 1);
@@ -379,8 +375,8 @@ mod tests {
 
     #[tokio::test]
     async fn log_ws_frame_binary_shows_metadata() {
-        use tokio::sync::{RwLock, broadcast};
         use std::collections::{HashMap, VecDeque};
+        use tokio::sync::{RwLock, broadcast};
 
         let (event_tx, _rx) = broadcast::channel(16);
         let state = Arc::new(super::super::handler::ProxyState {
@@ -401,7 +397,15 @@ mod tests {
 
         let session = Some("test-session".to_string());
 
-        log_ws_frame(&session, "wss://example.com/ws", "WS-IN", None, 4096, &state).await;
+        log_ws_frame(
+            &session,
+            "wss://example.com/ws",
+            "WS-IN",
+            None,
+            4096,
+            &state,
+        )
+        .await;
 
         let captured = state.captured.read().await;
         assert_eq!(captured.len(), 1);

--- a/server/src/proxy/websocket.rs
+++ b/server/src/proxy/websocket.rs
@@ -358,6 +358,7 @@ mod tests {
             pending_images: RwLock::new(HashMap::new()),
             ca: None,
             network_rules: Arc::new(super::super::rules::NetworkRulesEngine::new()),
+            proxy_modes: super::super::modes::ProxyModeStore::new(),
         });
 
         let session = Some("test-session".to_string());
@@ -389,6 +390,7 @@ mod tests {
             pending_images: RwLock::new(HashMap::new()),
             ca: None,
             network_rules: Arc::new(super::super::rules::NetworkRulesEngine::new()),
+            proxy_modes: super::super::modes::ProxyModeStore::new(),
         });
 
         let session = Some("test-session".to_string());

--- a/server/src/proxy/websocket.rs
+++ b/server/src/proxy/websocket.rs
@@ -1,0 +1,405 @@
+//! WebSocket relay for proxied connections (e.g. Codex WebSocket over reverse proxy).
+//!
+//! When a client sends an HTTP Upgrade: websocket request through the reverse proxy,
+//! the proxy establishes a WebSocket connection to the upstream and relays frames
+//! bidirectionally. Text frames are logged as ApiRequestLog entries with method
+//! "WS-OUT" (client→upstream) and "WS-IN" (upstream→client). Binary frames are
+//! logged as metadata only (size + opcode).
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use futures_util::{SinkExt, StreamExt};
+use tokio_tungstenite::tungstenite::Message as TungMessage;
+use tracing::{debug, info, warn};
+
+use super::mitm::{self, ApiRequestLog};
+
+/// Maximum text frame size to log in full (larger frames are truncated in logs)
+const MAX_LOG_FRAME_SIZE: usize = 64 * 1024; // 64 KB
+
+/// Relay WebSocket frames between client and upstream, logging text frames.
+///
+/// Both `client_ws` and `upstream_ws` are already upgraded WebSocket streams.
+/// This function runs until either side closes or an error occurs.
+pub async fn relay_frames(
+    client_ws: axum::extract::ws::WebSocket,
+    upstream_ws: tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    session_id: Option<String>,
+    url: String,
+    state: Arc<super::handler::ProxyState>,
+) {
+    let (mut upstream_tx, mut upstream_rx) = upstream_ws.split();
+    let (mut client_tx, mut client_rx) = client_ws.split();
+
+    let session_for_out = session_id.clone();
+    let url_for_out = url.clone();
+    let state_for_out = state.clone();
+
+    // Client → Upstream (WS-OUT)
+    let client_to_upstream = async {
+        while let Some(msg_result) = client_rx.next().await {
+            let msg = match msg_result {
+                Ok(m) => m,
+                Err(e) => {
+                    debug!(error = %e, "client WS recv error");
+                    break;
+                }
+            };
+
+            match msg {
+                axum::extract::ws::Message::Text(text) => {
+                    // Log text frame as WS-OUT
+                    log_ws_frame(
+                        &session_for_out,
+                        &url_for_out,
+                        "WS-OUT",
+                        Some(text.as_ref()),
+                        text.len(),
+                        &state_for_out,
+                    )
+                    .await;
+
+                    if upstream_tx
+                        .send(TungMessage::Text(text.as_str().into()))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                axum::extract::ws::Message::Binary(data) => {
+                    // Log binary frame as metadata only
+                    log_ws_frame(
+                        &session_for_out,
+                        &url_for_out,
+                        "WS-OUT",
+                        None,
+                        data.len(),
+                        &state_for_out,
+                    )
+                    .await;
+
+                    if upstream_tx
+                        .send(TungMessage::Binary(data))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                axum::extract::ws::Message::Ping(data) => {
+                    if upstream_tx
+                        .send(TungMessage::Ping(data))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                axum::extract::ws::Message::Pong(data) => {
+                    if upstream_tx
+                        .send(TungMessage::Pong(data))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                axum::extract::ws::Message::Close(frame) => {
+                    let close_frame = frame.map(|f| {
+                        tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                            code: tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::from(f.code),
+                            reason: f.reason.to_string().into(),
+                        }
+                    });
+                    let _ = upstream_tx.send(TungMessage::Close(close_frame)).await;
+                    break;
+                }
+            }
+        }
+    };
+
+    // Upstream → Client (WS-IN)
+    let upstream_to_client = async {
+        while let Some(msg_result) = upstream_rx.next().await {
+            let msg = match msg_result {
+                Ok(m) => m,
+                Err(e) => {
+                    debug!(error = %e, "upstream WS recv error");
+                    break;
+                }
+            };
+
+            match msg {
+                TungMessage::Text(text) => {
+                    // Log text frame as WS-IN
+                    log_ws_frame(
+                        &session_id,
+                        &url,
+                        "WS-IN",
+                        Some(text.as_ref()),
+                        text.len(),
+                        &state,
+                    )
+                    .await;
+
+                    if client_tx
+                        .send(axum::extract::ws::Message::Text(text.to_string().into()))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                TungMessage::Binary(data) => {
+                    // Log binary frame as metadata only
+                    log_ws_frame(&session_id, &url, "WS-IN", None, data.len(), &state).await;
+
+                    if client_tx
+                        .send(axum::extract::ws::Message::Binary(data))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                TungMessage::Ping(data) => {
+                    if client_tx
+                        .send(axum::extract::ws::Message::Ping(data))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                TungMessage::Pong(data) => {
+                    if client_tx
+                        .send(axum::extract::ws::Message::Pong(data))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                TungMessage::Close(frame) => {
+                    let close_frame = frame.map(|f| axum::extract::ws::CloseFrame {
+                        code: f.code.into(),
+                        reason: f.reason.to_string().into(),
+                    });
+                    let _ = client_tx
+                        .send(axum::extract::ws::Message::Close(close_frame))
+                        .await;
+                    break;
+                }
+                // Frame is a non-standard tungstenite variant — skip
+                _ => continue,
+            }
+        }
+    };
+
+    // Run both directions concurrently; stop when either side closes
+    tokio::select! {
+        _ = client_to_upstream => {}
+        _ = upstream_to_client => {}
+    }
+
+    info!(url = %url_for_out, "WebSocket relay ended");
+}
+
+/// Log a single WebSocket frame as an ApiRequestLog entry.
+///
+/// Text frames include the (redacted) body content; binary frames log only metadata.
+async fn log_ws_frame(
+    session_id: &Option<String>,
+    url: &str,
+    method: &str, // "WS-OUT" or "WS-IN"
+    text_body: Option<&str>,
+    frame_size: usize,
+    state: &super::handler::ProxyState,
+) {
+    let start = Instant::now();
+
+    let body_str = match text_body {
+        Some(text) if text.len() <= MAX_LOG_FRAME_SIZE => mitm::redact(text),
+        Some(text) => {
+            let truncated = &text[..MAX_LOG_FRAME_SIZE];
+            format!(
+                "{}... [truncated, {} bytes total]",
+                mitm::redact(truncated),
+                text.len()
+            )
+        }
+        None => format!("[binary frame, {} bytes]", frame_size),
+    };
+
+    let log_entry = ApiRequestLog {
+        id: uuid::Uuid::new_v4().to_string(),
+        session_id: session_id.clone(),
+        method: method.to_string(),
+        url: mitm::redact(url),
+        request_body: if method == "WS-OUT" {
+            body_str.clone()
+        } else {
+            String::new()
+        },
+        response_body: if method == "WS-IN" {
+            body_str.clone()
+        } else {
+            String::new()
+        },
+        status_code: 101,
+        latency_ms: start.elapsed().as_millis() as u64,
+        request_headers: vec![],
+        response_headers: vec![],
+        timestamp: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64,
+        request_size: if method == "WS-OUT" { frame_size } else { 0 },
+        response_size: if method == "WS-IN" { frame_size } else { 0 },
+        category: Some("Api".to_string()),
+    };
+
+    // Store in captured buffer + broadcast
+    {
+        let mut captured = state.captured.write().await;
+        if captured.len() >= super::handler::MAX_CAPTURED_REQUESTS {
+            captured.pop_front();
+        }
+        captured.push_back(log_entry.clone());
+    }
+    let _ = state.event_tx.send(log_entry);
+}
+
+/// Check if request headers indicate a WebSocket upgrade.
+pub fn is_websocket_upgrade(headers: &axum::http::HeaderMap) -> bool {
+    let has_upgrade = headers
+        .get(axum::http::header::UPGRADE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.eq_ignore_ascii_case("websocket"));
+
+    let has_connection_upgrade = headers
+        .get(axum::http::header::CONNECTION)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| {
+            v.split(',')
+                .any(|part| part.trim().eq_ignore_ascii_case("upgrade"))
+        });
+
+    has_upgrade && has_connection_upgrade
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderMap;
+
+    #[test]
+    fn detects_websocket_upgrade_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("upgrade", "websocket".parse().unwrap());
+        headers.insert("connection", "Upgrade".parse().unwrap());
+        assert!(is_websocket_upgrade(&headers));
+    }
+
+    #[test]
+    fn rejects_missing_upgrade_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("connection", "Upgrade".parse().unwrap());
+        assert!(!is_websocket_upgrade(&headers));
+    }
+
+    #[test]
+    fn rejects_non_websocket_upgrade() {
+        let mut headers = HeaderMap::new();
+        headers.insert("upgrade", "h2c".parse().unwrap());
+        headers.insert("connection", "Upgrade".parse().unwrap());
+        assert!(!is_websocket_upgrade(&headers));
+    }
+
+    #[test]
+    fn handles_connection_header_with_multiple_values() {
+        let mut headers = HeaderMap::new();
+        headers.insert("upgrade", "websocket".parse().unwrap());
+        headers.insert("connection", "keep-alive, Upgrade".parse().unwrap());
+        assert!(is_websocket_upgrade(&headers));
+    }
+
+    #[test]
+    fn case_insensitive_websocket() {
+        let mut headers = HeaderMap::new();
+        headers.insert("upgrade", "WebSocket".parse().unwrap());
+        headers.insert("connection", "upgrade".parse().unwrap());
+        assert!(is_websocket_upgrade(&headers));
+    }
+
+    #[test]
+    fn rejects_empty_headers() {
+        let headers = HeaderMap::new();
+        assert!(!is_websocket_upgrade(&headers));
+    }
+
+    #[tokio::test]
+    async fn log_ws_frame_text_redacts_keys() {
+        use tokio::sync::{RwLock, broadcast};
+        use std::collections::{HashMap, VecDeque};
+
+        let (event_tx, _rx) = broadcast::channel(16);
+        let state = Arc::new(super::super::handler::ProxyState {
+            client: reqwest::Client::new(),
+            event_tx,
+            captured: RwLock::new(VecDeque::new()),
+            intercept_modes: RwLock::new(HashMap::new()),
+            pending_intercepts: RwLock::new(HashMap::new()),
+            pending_response_intercepts: RwLock::new(HashMap::new()),
+            pending_images: RwLock::new(HashMap::new()),
+            ca: None,
+            network_rules: Arc::new(super::super::rules::NetworkRulesEngine::new()),
+        });
+
+        let session = Some("test-session".to_string());
+        let body_with_key = r#"{"key": "sk-ant-api03-secret123"}"#;
+
+        log_ws_frame(&session, "wss://example.com/ws", "WS-OUT", Some(body_with_key), body_with_key.len(), &state).await;
+
+        let captured = state.captured.read().await;
+        assert_eq!(captured.len(), 1);
+        let entry = &captured[0];
+        assert_eq!(entry.method, "WS-OUT");
+        assert!(!entry.request_body.contains("sk-ant-"));
+        assert!(entry.request_body.contains("[REDACTED]"));
+    }
+
+    #[tokio::test]
+    async fn log_ws_frame_binary_shows_metadata() {
+        use tokio::sync::{RwLock, broadcast};
+        use std::collections::{HashMap, VecDeque};
+
+        let (event_tx, _rx) = broadcast::channel(16);
+        let state = Arc::new(super::super::handler::ProxyState {
+            client: reqwest::Client::new(),
+            event_tx,
+            captured: RwLock::new(VecDeque::new()),
+            intercept_modes: RwLock::new(HashMap::new()),
+            pending_intercepts: RwLock::new(HashMap::new()),
+            pending_response_intercepts: RwLock::new(HashMap::new()),
+            pending_images: RwLock::new(HashMap::new()),
+            ca: None,
+            network_rules: Arc::new(super::super::rules::NetworkRulesEngine::new()),
+        });
+
+        let session = Some("test-session".to_string());
+
+        log_ws_frame(&session, "wss://example.com/ws", "WS-IN", None, 4096, &state).await;
+
+        let captured = state.captured.read().await;
+        assert_eq!(captured.len(), 1);
+        let entry = &captured[0];
+        assert_eq!(entry.method, "WS-IN");
+        assert!(entry.response_body.contains("binary frame"));
+        assert!(entry.response_body.contains("4096"));
+    }
+}

--- a/server/src/proxy/websocket.rs
+++ b/server/src/proxy/websocket.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 
 use futures_util::{SinkExt, StreamExt};
 use tokio_tungstenite::tungstenite::Message as TungMessage;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use super::mitm::{self, ApiRequestLog};
 
@@ -360,6 +360,7 @@ mod tests {
             network_rules: Arc::new(super::super::rules::NetworkRulesEngine::new()),
             proxy_modes: super::super::modes::ProxyModeStore::new(),
             inject_store: super::super::inject::InjectStore::new(),
+            rewrite_store: super::super::rewrite::RewriteStore::new(),
         });
 
         let session = Some("test-session".to_string());
@@ -393,6 +394,7 @@ mod tests {
             network_rules: Arc::new(super::super::rules::NetworkRulesEngine::new()),
             proxy_modes: super::super::modes::ProxyModeStore::new(),
             inject_store: super::super::inject::InjectStore::new(),
+            rewrite_store: super::super::rewrite::RewriteStore::new(),
         });
 
         let session = Some("test-session".to_string());

--- a/server/src/proxy/websocket.rs
+++ b/server/src/proxy/websocket.rs
@@ -361,6 +361,7 @@ mod tests {
             proxy_modes: super::super::modes::ProxyModeStore::new(),
             inject_store: super::super::inject::InjectStore::new(),
             rewrite_store: super::super::rewrite::RewriteStore::new(),
+            key_store: super::super::keys::KeyStore::new(),
         });
 
         let session = Some("test-session".to_string());
@@ -395,6 +396,7 @@ mod tests {
             proxy_modes: super::super::modes::ProxyModeStore::new(),
             inject_store: super::super::inject::InjectStore::new(),
             rewrite_store: super::super::rewrite::RewriteStore::new(),
+            key_store: super::super::keys::KeyStore::new(),
         });
 
         let session = Some("test-session".to_string());

--- a/server/src/proxy/websocket.rs
+++ b/server/src/proxy/websocket.rs
@@ -359,6 +359,7 @@ mod tests {
             ca: None,
             network_rules: Arc::new(super::super::rules::NetworkRulesEngine::new()),
             proxy_modes: super::super::modes::ProxyModeStore::new(),
+            inject_store: super::super::inject::InjectStore::new(),
         });
 
         let session = Some("test-session".to_string());
@@ -391,6 +392,7 @@ mod tests {
             ca: None,
             network_rules: Arc::new(super::super::rules::NetworkRulesEngine::new()),
             proxy_modes: super::super::modes::ProxyModeStore::new(),
+            inject_store: super::super::inject::InjectStore::new(),
         });
 
         let session = Some("test-session".to_string());


### PR DESCRIPTION
## Summary

Implements the remaining phases of Issue #108 (Full Network Proxy) — 11 increments covering Phase 0.3 through 1.8:

- **WebSocket relay** for Codex through reverse proxy with frame-level logging (WS-OUT/WS-IN)
- **Category chips** filter bar with per-category counts and colored dots in request rows
- **Rule editor** panel with add/delete form + right-click context menu (Block domain/Block category)
- **Decoded body view** with JSON pretty-print, base64 auto-decode, Gemini/OpenAI SSE parsers, copy decoded
- **5-mode network filter** (Auto/Manual/Custom/Pure/Lockdown) with per-session DashMap storage
- **System prompt injection** with 6 configurable presets (AntiLaziness, VerifyEvidence, Speed, Verbose, GermanOnly, NoaideContext) + custom text, multi-LLM adapter (Anthropic/Google/OpenAI)
- **Request body rewrite** with model override, temperature, max_tokens, thinking type, and pure mode (strip to essentials)
- **Config persistence** to /data/noaide/ with debounced save (1s) and 30-day TTL cleanup
- **API key rotation** with AES-256-GCM encryption (ring HKDF from /etc/machine-id), round-robin selection, rate-limit tracking, auto-deactivation on 429
- **Audit log + cost tracking** with multi-provider token extraction (Anthropic/OpenAI/Gemini SSE), model price table, append-only JSONL writer, CSV export

### Stats
- 3,820 lines added across 21 files (8 new Rust modules, 6 new frontend components)
- 49 new unit tests (286 total pass)
- Frontend build + lint clean (0 errors)

## Test plan

- [x] `cargo remote -c -- build` passes
- [x] `cargo remote -c -- test -p noaide-server` — 286 passed, 0 failed
- [x] `cargo remote -c -- test -p noaide-server -- websocket` — 8 passed
- [x] `cargo remote -c -- test -p noaide-server -- modes` — 7 passed
- [x] `cargo remote -c -- test -p noaide-server -- inject` — 9 passed
- [x] `cargo remote -c -- test -p noaide-server -- rewrite` — 7 passed
- [x] `cargo remote -c -- test -p noaide-server -- persist` — 4 passed
- [x] `cargo remote -c -- test -p noaide-server -- keys` — 7 passed
- [x] `cargo remote -c -- test -p noaide-server -- audit` — 7 passed
- [x] `npm run build` — built in 7.83s
- [x] `npm run lint` — 0 errors, 20 warnings (all pre-existing)

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)