### PR TITLE
fix(proxy): finalize retest fixes and runtime guards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4240,7 +4240,11 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite 0.26.2",
 ]
 
@@ -4462,6 +4466,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,8 @@ thiserror = "2"
 anyhow = "1"
 zstd = "0.13"
 
-# WebSocket client (for whisper proxy)
-tokio-tungstenite = "0.26"
+# WebSocket client (Codex + other WSS upstreams)
+tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }
 
 # TLS MITM (CONNECT proxy)
 rcgen = { version = "0.14", features = ["pem", "x509-parser"] }
@@ -90,4 +90,3 @@ rustls-native-certs = "0.8"
 
 # Git integration
 git2 = "0.20"
-

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
-import { Router, Route } from "@solidjs/router";
-import { createContext, useContext, createSignal, Show, For, onMount, onCleanup } from "solid-js";
+import { Router, Route, useLocation, useNavigate, useParams } from "@solidjs/router";
+import { createContext, useContext, createSignal, Show, For, onMount, onCleanup, createEffect, untrack } from "solid-js";
 import ThreePanel from "./layouts/ThreePanel";
 import MobileLayout from "./layouts/MobileLayout";
 import ChatPanel from "./components/chat/ChatPanel";
@@ -246,8 +246,39 @@ function Shell() {
   const [centerTab, setCenterTab] = createSignal<CenterTabId>("chat");
 
   const store = useSession();
+  const params = useParams<{ id?: string }>();
+  const location = useLocation();
+  const navigate = useNavigate();
   const isMac2 = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform);
   const mod = isMac2 ? "\u2318" : "Ctrl+";
+
+  createEffect(() => {
+    const routeSessionId = params.id ?? null;
+    if (!routeSessionId) return;
+    const activeSessionId = untrack(() => store.state.activeSessionId);
+    if (routeSessionId !== activeSessionId) {
+      store.setActiveSession(routeSessionId);
+    }
+  });
+
+  createEffect(() => {
+    const activeSessionId = store.state.activeSessionId;
+    const routeSessionId = params.id ?? null;
+    const pathname = location.pathname;
+
+    if (!activeSessionId) {
+      if (routeSessionId) return;
+      if (pathname !== "/") {
+        navigate("/", { replace: true });
+      }
+      return;
+    }
+
+    const targetPath = `/session/${activeSessionId}`;
+    if (pathname !== targetPath) {
+      navigate(targetPath, { replace: true });
+    }
+  });
 
   const commands = () => {
     const cmds = [

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -362,6 +362,36 @@ export default function ChatPanel() {
     return riCache;
   });
 
+  const emptyState = createMemo(() => {
+    const activeSessionId = store.state.activeSessionId;
+    if (!activeSessionId) {
+      return {
+        title: "noaide",
+        subtitle: "Select a session to begin",
+      };
+    }
+
+    const session = store.activeSession();
+    if (!session) {
+      return {
+        title: "Loading session",
+        subtitle: "Syncing the selected session...",
+      };
+    }
+
+    if (store.state.orbState !== "idle" || session.status === "active") {
+      return {
+        title: "Session starting",
+        subtitle: "The CLI is booting. You can send the first message once the prompt is ready.",
+      };
+    }
+
+    return {
+      title: "Session ready",
+      subtitle: "Send the first message to begin this conversation.",
+    };
+  });
+
   const maxTokensInSession = createMemo(() => {
     renderItems(); // reactive dependency
     return riMaxTokens || 1;
@@ -672,7 +702,7 @@ export default function ChatPanel() {
                     "letter-spacing": "-0.02em",
                   }}
                 >
-                  noaide
+                  {emptyState().title}
                 </div>
                 <div style={{
                   "font-size": "12px",
@@ -680,7 +710,7 @@ export default function ChatPanel() {
                   color: "var(--dim, #68687a)",
                   "letter-spacing": "0.05em",
                 }}>
-                  Select a session to begin
+                  {emptyState().subtitle}
                 </div>
               </div>
             }

--- a/frontend/src/components/mobile/BottomTabBar.tsx
+++ b/frontend/src/components/mobile/BottomTabBar.tsx
@@ -38,6 +38,7 @@ export default function BottomTabBar(props: { activeTab: TabId; onTabChange: (ta
           const isActive = () => props.activeTab === tab.id;
           return (
             <button
+              data-testid={`tab-${tab.id}`}
               onClick={() => {
                 haptic.tap();
                 props.onTabChange(tab.id);

--- a/frontend/src/components/network/AuditPanel.tsx
+++ b/frontend/src/components/network/AuditPanel.tsx
@@ -17,10 +17,15 @@ interface AuditEntry {
 
 export default function AuditPanel() {
   const store = useSession();
+  const [expanded, setExpanded] = createSignal(false);
   const [entries, setEntries] = createSignal<AuditEntry[]>([]);
 
+  function apiBase() {
+    return store.state.httpApiUrl || window.location.origin;
+  }
+
   async function fetchAudit() {
-    const base = store.state.httpApiUrl;
+    const base = apiBase();
     if (!base) return;
     const sid = store.state.activeSessionId;
     const url = sid
@@ -36,9 +41,15 @@ export default function AuditPanel() {
   }
 
   function exportCsv() {
-    const base = store.state.httpApiUrl;
+    const base = apiBase();
     if (!base) return;
     window.open(`${base}/api/proxy/audit/export?format=csv&limit=10000`, "_blank");
+  }
+
+  function exportJson() {
+    const base = apiBase();
+    if (!base) return;
+    window.open(`${base}/api/proxy/audit/export?format=json&limit=10000`, "_blank");
   }
 
   onMount(() => {
@@ -60,56 +71,114 @@ export default function AuditPanel() {
         overflow: "auto",
       }}
     >
-      <div style={{ display: "flex", "justify-content": "space-between", "align-items": "center", "margin-bottom": "6px" }}>
-        <div style={{ "font-size": "11px", "font-weight": "600", color: "var(--ctp-text)" }}>
-          Audit Log — ${totalCost().toFixed(4)}
-        </div>
-        <button
-          data-testid="audit-export-csv"
-          onClick={exportCsv}
-          style={{
-            padding: "2px 6px",
-            "font-size": "9px",
-            background: "var(--ctp-surface0)",
-            border: "1px solid var(--ctp-surface1)",
-            "border-radius": "3px",
-            color: "var(--ctp-subtext0)",
-            cursor: "pointer",
-          }}
-        >
-          CSV
-        </button>
-      </div>
+      <button
+        data-testid="audit-section"
+        onClick={() => {
+          const next = !expanded();
+          setExpanded(next);
+          if (next) {
+            void fetchAudit();
+          }
+        }}
+        style={{
+          width: "100%",
+          display: "flex",
+          "align-items": "center",
+          "justify-content": "space-between",
+          gap: "8px",
+          padding: "0",
+          background: "transparent",
+          border: "none",
+          color: "var(--ctp-text)",
+          cursor: "pointer",
+          "font-size": "11px",
+          "font-weight": "600",
+        }}
+      >
+        <span>Audit Log — ${totalCost().toFixed(4)}</span>
+        <span style={{ "font-size": "9px", color: "var(--ctp-overlay0)" }}>
+          {entries().length} entries
+        </span>
+      </button>
 
-      <Show when={entries().length > 0} fallback={<div style={{ "font-size": "10px", color: "var(--ctp-overlay0)" }}>No audit entries</div>}>
-        <table style={{ width: "100%", "font-size": "10px", "border-collapse": "collapse" }}>
-          <thead>
-            <tr style={{ color: "var(--ctp-overlay0)", "text-align": "left" }}>
-              <th style={{ padding: "2px 4px" }}>Time</th>
-              <th style={{ padding: "2px 4px" }}>Model</th>
-              <th style={{ padding: "2px 4px" }}>In</th>
-              <th style={{ padding: "2px 4px" }}>Out</th>
-              <th style={{ padding: "2px 4px" }}>Cost</th>
-              <th style={{ padding: "2px 4px" }}>Latency</th>
-            </tr>
-          </thead>
-          <tbody>
-            <For each={entries()}>
-              {(entry) => (
-                <tr style={{ "border-top": "1px solid var(--ctp-surface0)" }}>
-                  <td style={{ padding: "2px 4px", color: "var(--ctp-overlay1)" }}>
-                    {new Date(entry.timestamp).toLocaleTimeString()}
-                  </td>
-                  <td style={{ padding: "2px 4px", color: "var(--ctp-blue)" }}>{entry.model}</td>
-                  <td style={{ padding: "2px 4px", color: "var(--ctp-text)" }}>{entry.input_tokens}</td>
-                  <td style={{ padding: "2px 4px", color: "var(--ctp-text)" }}>{entry.output_tokens}</td>
-                  <td style={{ padding: "2px 4px", color: "var(--ctp-green)" }}>${entry.cost_usd.toFixed(4)}</td>
-                  <td style={{ padding: "2px 4px", color: "var(--ctp-overlay1)" }}>{entry.latency_ms}ms</td>
-                </tr>
-              )}
-            </For>
-          </tbody>
-        </table>
+      <Show when={expanded()}>
+        <div style={{ display: "grid", gap: "6px", "margin-top": "6px" }}>
+          <div style={{ display: "flex", "justify-content": "flex-end", gap: "6px" }}>
+            <button
+              data-testid="audit-export-csv"
+              onClick={exportCsv}
+              style={{
+                padding: "2px 6px",
+                "font-size": "9px",
+                background: "var(--ctp-surface0)",
+                border: "1px solid var(--ctp-surface1)",
+                "border-radius": "3px",
+                color: "var(--ctp-subtext0)",
+                cursor: "pointer",
+              }}
+            >
+              CSV
+            </button>
+            <button
+              data-testid="audit-export-json"
+              onClick={exportJson}
+              style={{
+                padding: "2px 6px",
+                "font-size": "9px",
+                background: "var(--ctp-surface0)",
+                border: "1px solid var(--ctp-surface1)",
+                "border-radius": "3px",
+                color: "var(--ctp-subtext0)",
+                cursor: "pointer",
+              }}
+            >
+              JSON
+            </button>
+          </div>
+
+          <table
+            data-testid="audit-table"
+            style={{ width: "100%", "font-size": "10px", "border-collapse": "collapse" }}
+          >
+            <thead>
+              <tr style={{ color: "var(--ctp-overlay0)", "text-align": "left" }}>
+                <th style={{ padding: "2px 4px" }}>Time</th>
+                <th style={{ padding: "2px 4px" }}>Model</th>
+                <th style={{ padding: "2px 4px" }}>In</th>
+                <th style={{ padding: "2px 4px" }}>Out</th>
+                <th style={{ padding: "2px 4px" }}>Cost</th>
+                <th style={{ padding: "2px 4px" }}>Latency</th>
+              </tr>
+            </thead>
+            <tbody>
+              <Show
+                when={entries().length > 0}
+                fallback={(
+                  <tr style={{ "border-top": "1px solid var(--ctp-surface0)" }}>
+                    <td colSpan={6} style={{ padding: "6px 4px", color: "var(--ctp-overlay0)" }}>
+                      No audit entries
+                    </td>
+                  </tr>
+                )}
+              >
+                <For each={entries()}>
+                  {(entry) => (
+                    <tr style={{ "border-top": "1px solid var(--ctp-surface0)" }}>
+                      <td style={{ padding: "2px 4px", color: "var(--ctp-overlay1)" }}>
+                        {new Date(entry.timestamp).toLocaleTimeString()}
+                      </td>
+                      <td style={{ padding: "2px 4px", color: "var(--ctp-blue)" }}>{entry.model}</td>
+                      <td style={{ padding: "2px 4px", color: "var(--ctp-text)" }}>{entry.input_tokens}</td>
+                      <td style={{ padding: "2px 4px", color: "var(--ctp-text)" }}>{entry.output_tokens}</td>
+                      <td style={{ padding: "2px 4px", color: "var(--ctp-green)" }}>${entry.cost_usd.toFixed(4)}</td>
+                      <td style={{ padding: "2px 4px", color: "var(--ctp-overlay1)" }}>{entry.latency_ms}ms</td>
+                    </tr>
+                  )}
+                </For>
+              </Show>
+            </tbody>
+          </table>
+        </div>
       </Show>
     </div>
   );

--- a/frontend/src/components/network/InjectPanel.test.tsx
+++ b/frontend/src/components/network/InjectPanel.test.tsx
@@ -1,0 +1,182 @@
+import { render, fireEvent, screen, waitFor, cleanup } from "@solidjs/testing-library";
+import { createStore } from "solid-js/store";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import InjectPanel from "./InjectPanel";
+
+const [sessionState, setSessionState] = createStore({
+  httpApiUrl: "http://localhost:8080",
+  activeSessionId: "session-a" as string | null,
+  connectionStatus: "connected" as "connecting" | "connected" | "disconnected",
+});
+
+vi.mock("../../App", () => ({
+  useSession: () => ({
+    state: sessionState,
+  }),
+}));
+
+describe("InjectPanel", () => {
+  beforeEach(() => {
+    setSessionState("httpApiUrl", "http://localhost:8080");
+    setSessionState("activeSessionId", "session-a");
+    setSessionState("connectionStatus", "connected");
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("reloads injection config when the active session changes", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (!init?.method || init.method === "GET") {
+        if (url.endsWith("/session-a")) {
+          return new Response(
+            JSON.stringify({
+              presets: ["anti_laziness", "noaide_context"],
+              custom_text: "Session A custom",
+            }),
+            { status: 200 },
+          );
+        }
+
+        if (url.endsWith("/session-b")) {
+          return new Response(
+            JSON.stringify({
+              presets: ["speed"],
+              custom_text: "Session B custom",
+            }),
+            { status: 200 },
+          );
+        }
+      }
+
+      return new Response(null, { status: 404 });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(() => <InjectPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("inject-preset-anti_laziness").getAttribute("aria-pressed")).toBe("true");
+      expect((screen.getByTestId("inject-custom-text") as HTMLTextAreaElement).value).toBe("Session A custom");
+    });
+
+    setSessionState("activeSessionId", "session-b");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("inject-preset-anti_laziness").getAttribute("aria-pressed")).toBe("false");
+      expect(screen.getByTestId("inject-preset-speed").getAttribute("aria-pressed")).toBe("true");
+      expect((screen.getByTestId("inject-custom-text") as HTMLTextAreaElement).value).toBe("Session B custom");
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "http://localhost:8080/api/proxy/inject/session-a",
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "http://localhost:8080/api/proxy/inject/session-b",
+    );
+  });
+
+  it("persists the next preset selection when Anti-Laziness is toggled", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (!init?.method || init.method === "GET") {
+        expect(url).toBe("http://localhost:8080/api/proxy/inject/session-a");
+        return new Response(
+          JSON.stringify({
+            presets: ["noaide_context"],
+            custom_text: "",
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(null, { status: 200 });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(() => <InjectPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("inject-preset-noaide_context").getAttribute("aria-pressed")).toBe("true");
+      expect(screen.getByTestId("inject-preset-anti_laziness").getAttribute("aria-pressed")).toBe("false");
+    });
+
+    fireEvent.click(screen.getByTestId("inject-preset-anti_laziness"));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    const saveCall = fetchMock.mock.calls[1];
+    expect(saveCall[0]).toBe("http://localhost:8080/api/proxy/inject/session-a");
+    expect(saveCall[1]).toMatchObject({
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        presets: ["noaide_context", "anti_laziness"],
+        custom_text: null,
+      }),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("inject-preset-anti_laziness").getAttribute("aria-pressed")).toBe("true");
+      expect(screen.getByTestId("inject-save-state").textContent).toContain("Saved");
+    });
+  });
+
+  it("reloads and clears stale inject state when the backend reconnects fresh", async () => {
+    let fetchCount = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      expect(url).toBe("http://localhost:8080/api/proxy/inject/session-a");
+      fetchCount += 1;
+
+      if (fetchCount === 1) {
+        return new Response(
+          JSON.stringify({
+            presets: ["anti_laziness", "noaide_context"],
+            custom_text: "Old backend state",
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          presets: ["noaide_context"],
+          custom_text: null,
+        }),
+        { status: 200 },
+      );
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(() => <InjectPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("inject-preset-anti_laziness").getAttribute("aria-pressed")).toBe("true");
+      expect((screen.getByTestId("inject-custom-text") as HTMLTextAreaElement).value).toBe("Old backend state");
+    });
+
+    setSessionState("connectionStatus", "disconnected");
+    setSessionState("connectionStatus", "connected");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("inject-preset-anti_laziness").getAttribute("aria-pressed")).toBe("false");
+      expect(screen.getByTestId("inject-preset-noaide_context").getAttribute("aria-pressed")).toBe("true");
+      expect((screen.getByTestId("inject-custom-text") as HTMLTextAreaElement).value).toBe("");
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/components/network/InjectPanel.tsx
+++ b/frontend/src/components/network/InjectPanel.tsx
@@ -1,133 +1,631 @@
-import { createSignal, For, onMount } from "solid-js";
+import { createEffect, createMemo, createSignal, For, on, onCleanup, Show } from "solid-js";
 import { useSession } from "../../App";
 
-const PRESETS = [
-  { id: "noaide_context", label: "noaide Context" },
-  { id: "anti_laziness", label: "Anti-Laziness" },
-  { id: "verify_evidence", label: "Verify Evidence" },
-  { id: "speed", label: "Speed" },
-  { id: "verbose", label: "Verbose" },
-  { id: "german_only", label: "German Only" },
+type PresetMeta = {
+  id: string;
+  label: string;
+  description: string;
+  accent: string;
+  badge?: string;
+};
+
+const DEFAULT_PRESETS = ["noaide_context"];
+
+const PRESETS: PresetMeta[] = [
+  {
+    id: "anti_laziness",
+    label: "Anti-Laziness",
+    description: "Forces complete work and rejects placeholder snippets or partial file dumps.",
+    accent: "var(--ctp-peach)",
+    badge: "Strict",
+  },
+  {
+    id: "verify_evidence",
+    label: "Verify Evidence",
+    description: "Requires command output, file contents, measurements, or other concrete proof.",
+    accent: "var(--ctp-blue)",
+    badge: "Traceable",
+  },
+  {
+    id: "speed",
+    label: "Speed",
+    description: "Biases toward concise answers, minimal framing, and fast execution.",
+    accent: "var(--ctp-green)",
+    badge: "Lean",
+  },
+  {
+    id: "verbose",
+    label: "Verbose",
+    description: "Asks for fuller explanations, more context, and explicit tradeoff coverage.",
+    accent: "var(--ctp-mauve)",
+    badge: "Detailed",
+  },
+  {
+    id: "german_only",
+    label: "German Only",
+    description: "Keeps the agent's communication in German while leaving code identifiers intact.",
+    accent: "var(--ctp-yellow)",
+    badge: "Locale",
+  },
+  {
+    id: "noaide_context",
+    label: "noaide Context",
+    description: "Adds the IDE-specific media and rendering context that noaide supports.",
+    accent: "var(--ctp-teal)",
+    badge: "Default",
+  },
 ] as const;
+
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+type RewriteConfigPayload = {
+  model_override?: string | null;
+  temperature?: number | null;
+  max_tokens?: number | null;
+  thinking_type?: string | null;
+  pure_mode?: boolean;
+  strip_system_prompt?: boolean;
+  strip_tools?: boolean;
+};
+
+type SpeedRewriteDefaults = {
+  model_override: string;
+  temperature: number;
+  max_tokens: number;
+};
 
 export default function InjectPanel() {
   const store = useSession();
-  const [activePresets, setActivePresets] = createSignal<string[]>(["noaide_context"]);
+  const [activePresets, setActivePresets] = createSignal<string[]>(DEFAULT_PRESETS);
   const [customText, setCustomText] = createSignal("");
+  const [saveState, setSaveState] = createSignal<SaveState>("idle");
 
-  async function fetchConfig() {
-    const base = store.state.httpApiUrl;
-    const sid = store.state.activeSessionId;
-    if (!base || !sid) return;
-    try {
-      const res = await fetch(`${base}/api/proxy/inject/${sid}`);
-      if (res.ok) {
-        const data = await res.json();
-        setActivePresets(data.presets || ["noaide_context"]);
-        setCustomText(data.custom_text || "");
-      }
-    } catch { /* ignore */ }
+  let fetchGeneration = 0;
+  let saveGeneration = 0;
+  let saveStateTimer: number | undefined;
+
+  onCleanup(() => {
+    if (saveStateTimer) {
+      window.clearTimeout(saveStateTimer);
+    }
+  });
+
+  function scheduleSaveStateReset() {
+    if (saveStateTimer) {
+      window.clearTimeout(saveStateTimer);
+    }
+    saveStateTimer = window.setTimeout(() => {
+      setSaveState("idle");
+    }, 1400);
   }
 
-  async function saveConfig() {
+  function resetLocalState(nextSaveState: SaveState = "idle") {
+    setActivePresets(DEFAULT_PRESETS);
+    setCustomText("");
+    setSaveState(nextSaveState);
+  }
+
+  async function fetchConfig(base: string, sid: string) {
+    const currentFetch = ++fetchGeneration;
+    try {
+      const res = await fetch(`${base}/api/proxy/inject/${sid}`);
+      if (!res.ok) {
+        if (currentFetch !== fetchGeneration) return;
+        resetLocalState(res.status === 404 ? "idle" : "error");
+        if (res.status !== 404) {
+          scheduleSaveStateReset();
+        }
+        return;
+      }
+      const data = await res.json() as { presets?: string[]; custom_text?: string | null };
+      if (currentFetch !== fetchGeneration) return;
+      setActivePresets(
+        Array.isArray(data.presets) && data.presets.length > 0
+          ? data.presets
+          : DEFAULT_PRESETS,
+      );
+      setCustomText(data.custom_text || "");
+      setSaveState("idle");
+    } catch {
+      if (currentFetch !== fetchGeneration) return;
+      resetLocalState("error");
+      scheduleSaveStateReset();
+    }
+  }
+
+  async function saveConfig(next: { presets?: string[]; customText?: string } = {}) {
     const base = store.state.httpApiUrl;
     const sid = store.state.activeSessionId;
     if (!base || !sid) return;
+
+    const presets = next.presets ?? activePresets();
+    const text = next.customText ?? customText();
+    const currentSave = ++saveGeneration;
+
+    setSaveState("saving");
+
     try {
-      await fetch(`${base}/api/proxy/inject/${sid}`, {
+      const res = await fetch(`${base}/api/proxy/inject/${sid}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          presets: activePresets(),
-          custom_text: customText() || null,
+          presets,
+          custom_text: text || null,
         }),
       });
-    } catch { /* ignore */ }
+      if (currentSave !== saveGeneration) return;
+      if (!res.ok) {
+        setSaveState("error");
+        scheduleSaveStateReset();
+        return;
+      }
+      setSaveState("saved");
+      scheduleSaveStateReset();
+    } catch {
+      if (currentSave !== saveGeneration) return;
+      setSaveState("error");
+      scheduleSaveStateReset();
+    }
   }
+
+  function speedRewriteDefaults(): SpeedRewriteDefaults {
+    switch (store.activeSession()?.cliType) {
+      case "codex":
+        return { model_override: "gpt-4o", temperature: 0, max_tokens: 1024 };
+      case "gemini":
+        return { model_override: "gemini-2.5-flash", temperature: 0, max_tokens: 1024 };
+      case "claude":
+      default:
+        return { model_override: "claude-haiku-4-5-20251001", temperature: 0, max_tokens: 1024 };
+    }
+  }
+
+  async function syncSpeedRewritePreset(enabled: boolean) {
+    const base = store.state.httpApiUrl;
+    const sid = store.state.activeSessionId;
+    if (!base || !sid) return;
+
+    const defaults = speedRewriteDefaults();
+    let current: RewriteConfigPayload = {};
+    try {
+      const res = await fetch(base + "/api/proxy/rewrite/" + sid);
+      if (res.ok) {
+        current = await res.json() as RewriteConfigPayload;
+      }
+
+      const next: RewriteConfigPayload = { ...current };
+      if (enabled) {
+        next.model_override = defaults.model_override;
+        next.temperature = defaults.temperature;
+        next.max_tokens = defaults.max_tokens;
+      } else {
+        if (next.model_override === defaults.model_override) next.model_override = null;
+        if (next.temperature === defaults.temperature) next.temperature = null;
+        if (next.max_tokens === defaults.max_tokens) next.max_tokens = null;
+      }
+
+      const put = await fetch(base + "/api/proxy/rewrite/" + sid, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(next),
+      });
+      if (put.ok) {
+        window.dispatchEvent(new CustomEvent("noaide:rewrite-config-updated", { detail: { sessionId: sid } }));
+      }
+    } catch {
+      /* keep inject save independent from rewrite sync */
+    }
+  }
+
+  createEffect(
+    on(
+      () => [
+        store.state.httpApiUrl,
+        store.state.activeSessionId,
+        store.state.connectionStatus,
+      ] as const,
+      ([base, sid, connectionStatus], previous) => {
+        const [previousBase, previousSid, previousConnectionStatus] = previous ?? [];
+        const scopeChanged = base !== previousBase || sid !== previousSid;
+        const reconnected =
+          previousConnectionStatus !== "connected" && connectionStatus === "connected";
+
+        if (!base || !sid) {
+          fetchGeneration++;
+          saveGeneration++;
+          resetLocalState();
+          return;
+        }
+
+        if (!scopeChanged && !reconnected) {
+          return;
+        }
+
+        saveGeneration++;
+        void fetchConfig(base, sid);
+      },
+    ),
+  );
+
+  const activePresetMeta = createMemo(() =>
+    PRESETS.filter((preset) => activePresets().includes(preset.id)),
+  );
+
+  const customInstructionCount = createMemo(() => {
+    const trimmed = customText().trim();
+    return trimmed ? trimmed.length : 0;
+  });
+
+  const summaryText = createMemo(() => {
+    const presetCount = activePresetMeta().length;
+    const customCount = customInstructionCount() > 0 ? 1 : 0;
+    const total = presetCount + customCount;
+    if (total === 0) return "No active injection rules";
+    if (customCount === 0) return `${presetCount} preset${presetCount === 1 ? "" : "s"} active`;
+    return `${presetCount} preset${presetCount === 1 ? "" : "s"} + custom text`;
+  });
 
   function togglePreset(presetId: string) {
     const current = activePresets();
-    if (current.includes(presetId)) {
-      setActivePresets(current.filter((p) => p !== presetId));
-    } else {
-      setActivePresets([...current, presetId]);
+    const willEnable = !current.includes(presetId);
+    const nextPresets = willEnable
+      ? [...current, presetId]
+      : current.filter((preset) => preset !== presetId);
+
+    setActivePresets(nextPresets);
+    void saveConfig({ presets: nextPresets });
+    if (presetId === "speed") {
+      void syncSpeedRewritePreset(willEnable);
     }
-    void saveConfig();
   }
 
-  onMount(() => {
-    void fetchConfig();
-  });
+  function resetToDefault() {
+    const speedWasActive = activePresets().includes("speed");
+    setActivePresets(DEFAULT_PRESETS);
+    setCustomText("");
+    void saveConfig({ presets: DEFAULT_PRESETS, customText: "" });
+    if (speedWasActive) {
+      void syncSpeedRewritePreset(false);
+    }
+  }
+
+  const statusColor = () => {
+    switch (saveState()) {
+      case "saved":
+        return "var(--ctp-green)";
+      case "saving":
+        return "var(--ctp-yellow)";
+      case "error":
+        return "var(--ctp-red)";
+      default:
+        return "var(--ctp-overlay0)";
+    }
+  };
+
+  const statusLabel = () => {
+    switch (saveState()) {
+      case "saved":
+        return "Saved";
+      case "saving":
+        return "Saving...";
+      case "error":
+        return "Sync error";
+      default:
+        return "Session scoped";
+    }
+  };
 
   return (
-    <div
-      data-testid="inject-panel"
+    <section data-testid="inject-section">
+      <div
+        data-testid="inject-panel"
       style={{
-        padding: "8px 12px",
+        padding: "10px 12px 12px",
         "border-top": "1px solid var(--ctp-surface0)",
         background: "var(--ctp-mantle)",
       }}
     >
       <div
         style={{
-          "font-size": "11px",
-          "font-weight": "600",
-          color: "var(--ctp-text)",
-          "margin-bottom": "6px",
+          display: "flex",
+          "align-items": "flex-start",
+          "justify-content": "space-between",
+          gap: "12px",
+          "margin-bottom": "10px",
         }}
       >
-        System Prompt Injection
+        <div>
+          <div
+            style={{
+              "font-size": "11px",
+              "font-weight": "700",
+              color: "var(--ctp-text)",
+              "letter-spacing": "0.02em",
+            }}
+          >
+            System Prompt Injection
+          </div>
+          <div
+            style={{
+              "font-size": "10px",
+              color: "var(--ctp-subtext0)",
+              "margin-top": "2px",
+              "max-width": "480px",
+              "line-height": "1.45",
+            }}
+          >
+            Shape the session's upstream system prompt before the next model request. Anti-Laziness
+            is surfaced first because it is the strictest completeness guard.
+          </div>
+        </div>
+
+        <div
+          data-testid="inject-save-state"
+          style={{
+            "font-size": "9px",
+            "font-weight": "700",
+            color: statusColor(),
+            padding: "4px 8px",
+            "border-radius": "999px",
+            border: `1px solid color-mix(in srgb, ${statusColor()} 35%, transparent)`,
+            background: `color-mix(in srgb, ${statusColor()} 14%, transparent)`,
+            "white-space": "nowrap",
+          }}
+        >
+          {statusLabel()}
+        </div>
       </div>
 
-      {/* Preset checkboxes */}
-      <div style={{ display: "flex", gap: "6px", "flex-wrap": "wrap", "margin-bottom": "6px" }}>
+      <div
+        style={{
+          display: "grid",
+          gap: "8px",
+          "grid-template-columns": "repeat(auto-fit, minmax(170px, 1fr))",
+          "margin-bottom": "10px",
+        }}
+      >
         <For each={PRESETS}>
-          {(preset) => (
-            <label
-              style={{
-                display: "flex",
-                "align-items": "center",
-                gap: "3px",
-                "font-size": "10px",
-                color: activePresets().includes(preset.id)
-                  ? "var(--ctp-text)"
-                  : "var(--ctp-overlay0)",
-                cursor: "pointer",
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={activePresets().includes(preset.id)}
-                onChange={() => togglePreset(preset.id)}
-                style={{ width: "12px", height: "12px" }}
-              />
-              {preset.label}
-            </label>
-          )}
+          {(preset) => {
+            const isActive = () => activePresets().includes(preset.id);
+            return (
+              <button
+                type="button"
+                data-testid={`inject-preset-${preset.id}`}
+                aria-pressed={isActive()}
+                onClick={() => togglePreset(preset.id)}
+                style={{
+                  display: "flex",
+                  "flex-direction": "column",
+                  gap: "8px",
+                  padding: "10px",
+                  "text-align": "left",
+                  border: `1px solid ${isActive() ? preset.accent : "var(--ctp-surface1)"}`,
+                  "border-radius": "8px",
+                  background: isActive()
+                    ? `linear-gradient(180deg, color-mix(in srgb, ${preset.accent} 16%, var(--ctp-surface0)), color-mix(in srgb, ${preset.accent} 7%, var(--ctp-mantle)))`
+                    : "linear-gradient(180deg, var(--ctp-surface0), color-mix(in srgb, var(--ctp-surface0) 55%, var(--ctp-mantle)))",
+                  color: "var(--ctp-text)",
+                  cursor: "pointer",
+                  "box-shadow": isActive() ? `0 0 0 1px color-mix(in srgb, ${preset.accent} 18%, transparent)` : "none",
+                  transition: "border-color 120ms ease, background 120ms ease, box-shadow 120ms ease",
+                  "min-height": "112px",
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    "align-items": "center",
+                    "justify-content": "space-between",
+                    gap: "8px",
+                  }}
+                >
+                  <div
+                    style={{
+                      display: "flex",
+                      "align-items": "center",
+                      gap: "6px",
+                      "flex-wrap": "wrap",
+                    }}
+                  >
+                    <span
+                      style={{
+                        "font-size": "11px",
+                        "font-weight": "700",
+                      }}
+                    >
+                      {preset.label}
+                    </span>
+                    <Show when={preset.badge}>
+                      <span
+                        style={{
+                          "font-size": "8px",
+                          "font-weight": "700",
+                          "letter-spacing": "0.05em",
+                          "text-transform": "uppercase",
+                          color: preset.accent,
+                          padding: "2px 5px",
+                          "border-radius": "999px",
+                          background: `color-mix(in srgb, ${preset.accent} 18%, transparent)`,
+                        }}
+                      >
+                        {preset.badge}
+                      </span>
+                    </Show>
+                  </div>
+
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      width: "18px",
+                      height: "18px",
+                      display: "inline-flex",
+                      "align-items": "center",
+                      "justify-content": "center",
+                      "border-radius": "999px",
+                      background: isActive()
+                        ? preset.accent
+                        : "color-mix(in srgb, var(--ctp-surface2) 50%, transparent)",
+                      color: isActive() ? "var(--ctp-base)" : "var(--ctp-overlay0)",
+                      "font-size": "11px",
+                      "font-weight": "700",
+                    }}
+                  >
+                    {isActive() ? "✓" : "+"}
+                  </span>
+                </div>
+
+                <div
+                  style={{
+                    "font-size": "10px",
+                    color: isActive() ? "var(--ctp-text)" : "var(--ctp-subtext0)",
+                    "line-height": "1.45",
+                  }}
+                >
+                  {preset.description}
+                </div>
+              </button>
+            );
+          }}
         </For>
       </div>
 
-      {/* Custom text */}
-      <textarea
-        data-testid="inject-custom-text"
-        placeholder="Custom injection text..."
-        value={customText()}
-        onInput={(e) => setCustomText(e.currentTarget.value)}
-        onBlur={() => void saveConfig()}
+      <div
         style={{
-          width: "100%",
-          "min-height": "40px",
-          padding: "4px 6px",
-          "font-size": "10px",
-          "font-family": "var(--font-mono)",
-          background: "var(--ctp-surface0)",
-          border: "1px solid var(--ctp-surface1)",
-          "border-radius": "3px",
-          color: "var(--ctp-text)",
-          resize: "vertical",
-          outline: "none",
+          display: "flex",
+          "align-items": "center",
+          "justify-content": "space-between",
+          gap: "8px",
+          "margin-bottom": "8px",
         }}
-      />
-    </div>
+      >
+        <div style={{ display: "flex", "align-items": "center", gap: "6px", "flex-wrap": "wrap" }}>
+          <span
+            style={{
+              "font-size": "9px",
+              "font-weight": "700",
+              color: "var(--ctp-overlay0)",
+              "text-transform": "uppercase",
+              "letter-spacing": "0.05em",
+            }}
+          >
+            Prompt Blend
+          </span>
+          <span
+            data-testid="inject-summary"
+            style={{ "font-size": "10px", color: "var(--ctp-subtext0)" }}
+          >
+            {summaryText()}
+          </span>
+        </div>
+
+        <button
+          type="button"
+          data-testid="inject-reset-defaults"
+          onClick={resetToDefault}
+          style={{
+            padding: "4px 8px",
+            "font-size": "9px",
+            "font-weight": "700",
+            color: "var(--ctp-subtext0)",
+            background: "var(--ctp-surface0)",
+            border: "1px solid var(--ctp-surface1)",
+            "border-radius": "999px",
+            cursor: "pointer",
+            "white-space": "nowrap",
+          }}
+        >
+          Reset defaults
+        </button>
+      </div>
+
+      <Show when={activePresetMeta().length > 0}>
+        <div
+          style={{
+            display: "flex",
+            gap: "6px",
+            "flex-wrap": "wrap",
+            "margin-bottom": "10px",
+          }}
+        >
+          <For each={activePresetMeta()}>
+            {(preset) => (
+              <span
+                style={{
+                  "font-size": "9px",
+                  "font-weight": "700",
+                  color: preset.accent,
+                  padding: "3px 7px",
+                  "border-radius": "999px",
+                  background: `color-mix(in srgb, ${preset.accent} 16%, transparent)`,
+                  border: `1px solid color-mix(in srgb, ${preset.accent} 30%, transparent)`,
+                }}
+              >
+                {preset.label}
+              </span>
+            )}
+          </For>
+        </div>
+      </Show>
+
+      <label
+        style={{
+          display: "flex",
+          "flex-direction": "column",
+          gap: "6px",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            "align-items": "center",
+            "justify-content": "space-between",
+            gap: "8px",
+          }}
+        >
+          <span
+            style={{
+              "font-size": "10px",
+              "font-weight": "600",
+              color: "var(--ctp-text)",
+            }}
+          >
+            Custom instructions
+          </span>
+          <span
+            style={{
+              "font-size": "9px",
+              color: "var(--ctp-overlay0)",
+            }}
+          >
+            {customInstructionCount() > 0
+              ? `${customInstructionCount()} chars`
+              : "Appended after presets"}
+          </span>
+        </div>
+
+        <textarea
+          data-testid="inject-custom-text"
+          placeholder="Add session-specific system instructions..."
+          value={customText()}
+          onInput={(e) => setCustomText(e.currentTarget.value)}
+          onBlur={() => void saveConfig({ customText: customText() })}
+          style={{
+            width: "100%",
+            "min-height": "72px",
+            padding: "8px 10px",
+            "font-size": "10px",
+            "line-height": "1.5",
+            "font-family": "var(--font-mono)",
+            background: "var(--ctp-surface0)",
+            border: "1px solid var(--ctp-surface1)",
+            "border-radius": "8px",
+            color: "var(--ctp-text)",
+            resize: "vertical",
+            outline: "none",
+          }}
+        />
+      </label>
+      </div>
+    </section>
   );
 }

--- a/frontend/src/components/network/KeyManagementPanel.tsx
+++ b/frontend/src/components/network/KeyManagementPanel.tsx
@@ -1,0 +1,321 @@
+import { createSignal, For, Show, onCleanup, onMount } from "solid-js";
+import { useSession } from "../../App";
+
+interface ApiKeyRecord {
+  id: string;
+  provider: string;
+  label: string;
+  masked_value: string;
+  active: boolean;
+  rate_limit_5h: number;
+  rate_limit_7d: number;
+  request_count: number;
+}
+
+const PROVIDERS = [
+  { value: "anthropic", label: "Anthropic" },
+  { value: "openai", label: "OpenAI" },
+  { value: "chatgpt", label: "ChatGPT" },
+  { value: "google", label: "Google" },
+  { value: "google-codeassist", label: "Google Code Assist" },
+];
+
+export default function KeyManagementPanel() {
+  const store = useSession();
+  const [expanded, setExpanded] = createSignal(false);
+  const [keys, setKeys] = createSignal<ApiKeyRecord[]>([]);
+  const [provider, setProvider] = createSignal("anthropic");
+  const [label, setLabel] = createSignal("");
+  const [keyValue, setKeyValue] = createSignal("");
+  const [saving, setSaving] = createSignal(false);
+
+  async function fetchKeys() {
+    const base = store.state.httpApiUrl;
+    if (!base) return;
+    try {
+      const res = await fetch(`${base}/api/proxy/keys`);
+      if (res.ok) {
+        const data = await res.json();
+        setKeys(data.keys || []);
+      }
+    } catch { /* ignore */ }
+  }
+
+  async function saveKey() {
+    const base = store.state.httpApiUrl;
+    if (!base || !label().trim() || !keyValue().trim()) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`${base}/api/proxy/keys`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          provider: provider(),
+          label: label().trim(),
+          key: keyValue().trim(),
+        }),
+      });
+      if (res.ok) {
+        setLabel("");
+        setKeyValue("");
+        await fetchKeys();
+      }
+    } catch { /* ignore */ }
+    setSaving(false);
+  }
+
+  async function updateKeyActive(id: string, active: boolean) {
+    const base = store.state.httpApiUrl;
+    if (!base) return;
+    try {
+      const res = await fetch(`${base}/api/proxy/keys/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ active }),
+      });
+      if (res.ok) {
+        await fetchKeys();
+      }
+    } catch { /* ignore */ }
+  }
+
+  async function deleteKey(id: string) {
+    const base = store.state.httpApiUrl;
+    if (!base) return;
+    try {
+      const res = await fetch(`${base}/api/proxy/keys/${id}`, { method: "DELETE" });
+      if (res.ok) {
+        await fetchKeys();
+      }
+    } catch { /* ignore */ }
+  }
+
+  onMount(() => {
+    void fetchKeys();
+    const interval = setInterval(() => { void fetchKeys(); }, 5000);
+    onCleanup(() => clearInterval(interval));
+  });
+
+  return (
+    <div
+      style={{
+        padding: "8px 12px",
+        "border-top": "1px solid var(--ctp-surface0)",
+        background: "var(--ctp-mantle)",
+      }}
+    >
+      <button
+        data-testid="keys-section"
+        onClick={() => setExpanded((v) => !v)}
+        style={{
+          width: "100%",
+          display: "flex",
+          "align-items": "center",
+          "justify-content": "space-between",
+          gap: "8px",
+          padding: "0",
+          background: "transparent",
+          border: "none",
+          color: "var(--ctp-text)",
+          cursor: "pointer",
+          "font-size": "11px",
+          "font-weight": "600",
+        }}
+      >
+        <span>API Keys</span>
+        <span style={{ "font-size": "9px", color: "var(--ctp-overlay0)" }}>
+          {keys().length} configured
+        </span>
+      </button>
+
+      <Show when={expanded()}>
+        <div style={{ display: "grid", gap: "8px", "margin-top": "8px" }}>
+          <div style={{ display: "flex", "justify-content": "space-between", "align-items": "center", gap: "8px" }}>
+            <div style={{ "font-size": "10px", color: "var(--ctp-overlay0)" }}>
+              Keys stay masked in the UI; only provider + preview are shown.
+            </div>
+            <button
+              data-testid="add-key-btn"
+              onClick={() => {
+                setLabel("Test Key");
+                setProvider("anthropic");
+              }}
+              style={{
+                padding: "4px 8px",
+                "font-size": "9px",
+                "font-weight": "700",
+                color: "var(--ctp-base)",
+                background: "var(--ctp-blue)",
+                border: "none",
+                "border-radius": "999px",
+                cursor: "pointer",
+              }}
+            >
+              Add key
+            </button>
+          </div>
+
+          <div
+            style={{
+              display: "grid",
+              gap: "8px",
+              "grid-template-columns": "repeat(auto-fit, minmax(140px, 1fr))",
+            }}
+          >
+            <label style={{ display: "grid", gap: "4px" }}>
+              <span style={{ "font-size": "9px", color: "var(--ctp-overlay0)" }}>Provider</span>
+              <select
+                value={provider()}
+                onChange={(e) => setProvider(e.currentTarget.value)}
+                style={{
+                  padding: "6px 8px",
+                  background: "var(--ctp-surface0)",
+                  border: "1px solid var(--ctp-surface1)",
+                  "border-radius": "6px",
+                  color: "var(--ctp-text)",
+                  "font-size": "10px",
+                }}
+              >
+                <For each={PROVIDERS}>
+                  {(item) => (
+                    <option value={item.value}>{item.label}</option>
+                  )}
+                </For>
+              </select>
+            </label>
+
+            <label style={{ display: "grid", gap: "4px" }}>
+              <span style={{ "font-size": "9px", color: "var(--ctp-overlay0)" }}>Label</span>
+              <input
+                data-testid="key-label-input"
+                value={label()}
+                onInput={(e) => setLabel(e.currentTarget.value)}
+                placeholder="Anthropic Primary"
+                style={{
+                  padding: "6px 8px",
+                  background: "var(--ctp-surface0)",
+                  border: "1px solid var(--ctp-surface1)",
+                  "border-radius": "6px",
+                  color: "var(--ctp-text)",
+                  "font-size": "10px",
+                }}
+              />
+            </label>
+
+            <label style={{ display: "grid", gap: "4px", "grid-column": "1 / -1" }}>
+              <span style={{ "font-size": "9px", color: "var(--ctp-overlay0)" }}>Key value</span>
+              <input
+                data-testid="key-value-input"
+                value={keyValue()}
+                onInput={(e) => setKeyValue(e.currentTarget.value)}
+                placeholder="sk-ant-..."
+                style={{
+                  padding: "6px 8px",
+                  background: "var(--ctp-surface0)",
+                  border: "1px solid var(--ctp-surface1)",
+                  "border-radius": "6px",
+                  color: "var(--ctp-text)",
+                  "font-size": "10px",
+                  "font-family": "var(--font-mono)",
+                }}
+              />
+            </label>
+          </div>
+
+          <div style={{ display: "flex", "justify-content": "flex-end" }}>
+            <button
+              data-testid="key-save-btn"
+              onClick={() => void saveKey()}
+              disabled={saving()}
+              style={{
+                padding: "5px 10px",
+                "font-size": "9px",
+                "font-weight": "700",
+                color: "var(--ctp-base)",
+                background: saving() ? "var(--ctp-surface1)" : "var(--neon-green, #00ff9d)",
+                border: "none",
+                "border-radius": "999px",
+                cursor: saving() ? "default" : "pointer",
+              }}
+            >
+              {saving() ? "Saving..." : "Save key"}
+            </button>
+          </div>
+
+          <Show
+            when={keys().length > 0}
+            fallback={<div style={{ "font-size": "10px", color: "var(--ctp-overlay0)" }}>No keys configured yet</div>}
+          >
+            <div style={{ display: "grid", gap: "6px" }}>
+              <For each={keys()}>
+                {(key) => (
+                  <div
+                    style={{
+                      display: "grid",
+                      gap: "6px",
+                      padding: "8px 10px",
+                      background: "var(--ctp-surface0)",
+                      border: "1px solid var(--ctp-surface1)",
+                      "border-radius": "8px",
+                    }}
+                  >
+                    <div style={{ display: "flex", "justify-content": "space-between", gap: "8px", "align-items": "center" }}>
+                      <div style={{ display: "grid", gap: "2px" }}>
+                        <div style={{ "font-size": "10px", color: key.active ? "var(--ctp-text)" : "var(--ctp-overlay0)" }}>
+                          {key.label} ({key.provider})
+                        </div>
+                        <div style={{ "font-size": "10px", color: "var(--ctp-overlay0)", "font-family": "var(--font-mono)" }}>
+                          {key.masked_value}
+                        </div>
+                      </div>
+                      <div style={{ display: "flex", gap: "6px", "align-items": "center" }}>
+                        <button
+                          data-testid={`key-toggle-${key.id}`}
+                          onClick={() => void updateKeyActive(key.id, !key.active)}
+                          style={{
+                            padding: "4px 8px",
+                            "font-size": "9px",
+                            "font-weight": "700",
+                            color: key.active ? "var(--ctp-base)" : "var(--ctp-text)",
+                            background: key.active ? "var(--ctp-green)" : "var(--ctp-surface1)",
+                            border: "none",
+                            "border-radius": "999px",
+                            cursor: "pointer",
+                          }}
+                        >
+                          {key.active ? "Active" : "Inactive"}
+                        </button>
+                        <button
+                          data-testid={`key-delete-${key.id}`}
+                          onClick={() => void deleteKey(key.id)}
+                          style={{
+                            padding: "4px 8px",
+                            "font-size": "9px",
+                            "font-weight": "700",
+                            color: "var(--ctp-base)",
+                            background: "var(--ctp-red)",
+                            border: "none",
+                            "border-radius": "999px",
+                            cursor: "pointer",
+                          }}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </div>
+
+                    <div style={{ display: "flex", gap: "12px", "font-size": "9px", color: "var(--ctp-overlay0)" }}>
+                      <span>{key.request_count} reqs</span>
+                      <span>5h {key.rate_limit_5h.toFixed(0)}%</span>
+                      <span>7d {key.rate_limit_7d.toFixed(0)}%</span>
+                    </div>
+                  </div>
+                )}
+              </For>
+            </div>
+          </Show>
+        </div>
+      </Show>
+    </div>
+  );
+}

--- a/frontend/src/components/network/NetworkPanel.tsx
+++ b/frontend/src/components/network/NetworkPanel.tsx
@@ -4,6 +4,10 @@ import RequestRow from "./RequestRow";
 import RequestDetail, { type RequestDetailFull } from "./RequestDetail";
 import InterceptQueue from "./InterceptQueue";
 import RuleEditor from "./RuleEditor";
+import InjectPanel from "./InjectPanel";
+import RewritePanel from "./RewritePanel";
+import RateLimitPanel from "./RateLimitPanel";
+import AuditPanel from "./AuditPanel";
 
 export default function NetworkPanel() {
   const store = useSession();
@@ -675,6 +679,16 @@ export default function NetworkPanel() {
           httpApiUrl={store.state.httpApiUrl!}
           refreshKey={rulesVersion()}
         />
+      </Show>
+
+      {/* Custom mode configuration panels */}
+      <Show when={proxyMode() === "custom" && store.state.activeSessionId}>
+        <>
+          <InjectPanel />
+          <RewritePanel />
+          <RateLimitPanel />
+          <AuditPanel />
+        </>
       </Show>
 
       {/* Request list */}

--- a/frontend/src/components/network/NetworkPanel.tsx
+++ b/frontend/src/components/network/NetworkPanel.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createMemo, Show, For, onMount, onCleanup } from "solid-js";
+import { createSignal, createMemo, Show, For, onMount, onCleanup, createEffect } from "solid-js";
 import { useSession } from "../../App";
 import RequestRow from "./RequestRow";
 import RequestDetail, { type RequestDetailFull } from "./RequestDetail";
@@ -17,6 +17,7 @@ export default function NetworkPanel() {
   const [categoryFilter, setCategoryFilter] = createSignal<string>("all");
   const [showRules, setShowRules] = createSignal(false);
   const [proxyMode, setProxyModeSignal] = createSignal("auto");
+  const [rulesVersion, setRulesVersion] = createSignal(0);
 
   async function fetchProxyMode() {
     const base = store.state.httpApiUrl;
@@ -141,6 +142,27 @@ export default function NetworkPanel() {
     onCleanup(() => clearInterval(interval));
   });
 
+  createEffect(() => {
+    const base = store.state.httpApiUrl;
+    const sid = store.state.activeSessionId;
+
+    setSelectedId(null);
+    setRequests([]);
+
+    if (!base) return;
+
+    void fetchRequests();
+    if (!sid) {
+      setPendingCount(0);
+      setInterceptMode("auto");
+      setProxyModeSignal("auto");
+      return;
+    }
+
+    void fetchInterceptStatus();
+    void fetchProxyMode();
+  });
+
   const filteredRequests = createMemo(() => {
     let items = requests();
     const query = filter().toLowerCase();
@@ -202,11 +224,14 @@ export default function NetworkPanel() {
     const sid = store.state.activeSessionId;
     if (!base || !sid) return;
     try {
-      await fetch(`${base}/api/proxy/quick-block`, {
+      const res = await fetch(`${base}/api/proxy/network-rules/${sid}/quick-block`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ session_id: sid, domain }),
+        body: JSON.stringify({ domain }),
       });
+      if (res.ok) {
+        setRulesVersion((v) => v + 1);
+      }
     } catch { /* ignore */ }
   }
 
@@ -215,16 +240,21 @@ export default function NetworkPanel() {
     const sid = store.state.activeSessionId;
     if (!base || !sid) return;
     try {
-      await fetch(`${base}/api/proxy/network-rules`, {
+      const res = await fetch(`${base}/api/proxy/network-rules/${sid}/rules`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          id: "",
           session_id: sid,
-          category_filter: category,
-          action: "block",
+          category_filter: category.toLowerCase(),
+          action: { type: "block" },
+          enabled: true,
           priority: 50,
         }),
       });
+      if (res.ok) {
+        setRulesVersion((v) => v + 1);
+      }
     } catch { /* ignore */ }
   }
 
@@ -371,17 +401,11 @@ export default function NetworkPanel() {
           <button
             data-testid="quick-block-btn"
             onClick={async () => {
-              const base = store.state.httpApiUrl;
-              const sid = store.state.activeSessionId;
               const req = selectedRequest();
-              if (!base || !sid || !req) return;
+              if (!req) return;
               try {
                 const domain = new URL(req.url).hostname;
-                await fetch(`${base}/api/proxy/quick-block`, {
-                  method: "POST",
-                  headers: { "Content-Type": "application/json" },
-                  body: JSON.stringify({ session_id: sid, domain }),
-                });
+                await quickBlockDomain(domain);
               } catch { /* ignore */ }
             }}
             style={{
@@ -646,7 +670,11 @@ export default function NetworkPanel() {
 
       {/* Rules Editor Panel */}
       <Show when={showRules() && store.state.activeSessionId}>
-        <RuleEditor />
+        <RuleEditor
+          sessionId={store.state.activeSessionId!}
+          httpApiUrl={store.state.httpApiUrl!}
+          refreshKey={rulesVersion()}
+        />
       </Show>
 
       {/* Request list */}

--- a/frontend/src/components/network/NetworkPanel.tsx
+++ b/frontend/src/components/network/NetworkPanel.tsx
@@ -6,6 +6,7 @@ import InterceptQueue from "./InterceptQueue";
 import RuleEditor from "./RuleEditor";
 import InjectPanel from "./InjectPanel";
 import RewritePanel from "./RewritePanel";
+import KeyManagementPanel from "./KeyManagementPanel";
 import RateLimitPanel from "./RateLimitPanel";
 import AuditPanel from "./AuditPanel";
 
@@ -142,6 +143,7 @@ export default function NetworkPanel() {
     const interval = setInterval(() => {
       fetchRequests();
       fetchInterceptStatus();
+      void fetchProxyMode();
     }, interceptMode() === "manual" ? 1000 : 2000);
     onCleanup(() => clearInterval(interval));
   });
@@ -276,6 +278,7 @@ export default function NetworkPanel() {
         style={{
           display: "flex",
           "align-items": "center",
+          "flex-wrap": "wrap",
           gap: "8px",
           padding: "8px 12px",
           "border-bottom": "1px solid var(--ctp-surface0)",
@@ -289,7 +292,8 @@ export default function NetworkPanel() {
           value={filter()}
           onInput={(e) => setFilter(e.currentTarget.value)}
           style={{
-            flex: "1",
+            flex: "1 1 140px",
+            "min-width": "0",
             padding: "4px 8px",
             background: "var(--ctp-surface0)",
             border: "1px solid var(--ctp-surface1)",
@@ -507,6 +511,7 @@ export default function NetworkPanel() {
                   request: { method: r.method, url: r.url, httpVersion: "HTTP/2", headers: [], queryString: [], bodySize: r.requestSize ?? -1 },
                   response: { status: r.statusCode, statusText: "", httpVersion: "HTTP/2", headers: [], content: { size: r.responseSize ?? -1, mimeType: "application/json" }, bodySize: r.responseSize ?? -1 },
                   timings: { send: 0, wait: r.latencyMs, receive: 0 },
+                  _traffic_category: r.category || "Unknown",
                 })),
               },
             };
@@ -587,7 +592,7 @@ export default function NetworkPanel() {
             const count = () =>
               cat === "All"
                 ? requests().length
-                : requests().filter((r) => (r.category || "Unknown") === cat).length;
+                : requests().filter((r) => (r.category || "unknown").toLowerCase() === cat.toLowerCase()).length;
             return (
               <button
                 data-testid={`category-chip-${cat.toLowerCase()}`}
@@ -686,6 +691,7 @@ export default function NetworkPanel() {
         <>
           <InjectPanel />
           <RewritePanel />
+          <KeyManagementPanel />
           <RateLimitPanel />
           <AuditPanel />
         </>

--- a/frontend/src/components/network/NetworkPanel.tsx
+++ b/frontend/src/components/network/NetworkPanel.tsx
@@ -169,7 +169,7 @@ export default function NetworkPanel() {
     }
 
     if (cat !== "all") {
-      items = items.filter((r) => (r.category || "Unknown") === cat);
+      items = items.filter((r) => (r.category || "unknown").toLowerCase() === cat.toLowerCase());
     }
 
     return items;

--- a/frontend/src/components/network/RateLimitPanel.tsx
+++ b/frontend/src/components/network/RateLimitPanel.tsx
@@ -13,10 +13,15 @@ interface KeyStatus {
 
 export default function RateLimitPanel() {
   const store = useSession();
+  const [expanded, setExpanded] = createSignal(false);
   const [keys, setKeys] = createSignal<KeyStatus[]>([]);
 
+  function apiBase() {
+    return store.state.httpApiUrl || window.location.origin;
+  }
+
   async function fetchStatus() {
-    const base = store.state.httpApiUrl;
+    const base = apiBase();
     if (!base) return;
     try {
       const res = await fetch(`${base}/api/proxy/keys/status`);
@@ -39,6 +44,9 @@ export default function RateLimitPanel() {
     return "var(--ctp-green)";
   }
 
+  const hasWarning = () =>
+    keys().some((key) => key.rate_limit_5h >= 80 || key.rate_limit_7d >= 80);
+
   return (
     <div
       data-testid="rate-limit-panel"
@@ -48,55 +56,105 @@ export default function RateLimitPanel() {
         background: "var(--ctp-mantle)",
       }}
     >
-      <div style={{ "font-size": "11px", "font-weight": "600", color: "var(--ctp-text)", "margin-bottom": "6px" }}>
-        Rate Limits
-      </div>
+      <button
+        data-testid="rate-limit-section"
+        onClick={() => {
+          const next = !expanded();
+          setExpanded(next);
+          if (next) {
+            void fetchStatus();
+          }
+        }}
+        style={{
+          width: "100%",
+          display: "flex",
+          "align-items": "center",
+          "justify-content": "space-between",
+          gap: "8px",
+          padding: "0",
+          background: "transparent",
+          border: "none",
+          color: "var(--ctp-text)",
+          cursor: "pointer",
+          "font-size": "11px",
+          "font-weight": "600",
+        }}
+      >
+        <span>Rate Limits</span>
+        <span style={{ "font-size": "9px", color: "var(--ctp-overlay0)" }}>
+          {keys().length} keys
+        </span>
+      </button>
 
-      <Show when={keys().length > 0} fallback={<div style={{ "font-size": "10px", color: "var(--ctp-overlay0)" }}>No API keys configured</div>}>
-        <For each={keys()}>
-          {(key) => (
-            <div style={{ "margin-bottom": "6px" }}>
-              <div style={{ display: "flex", "justify-content": "space-between", "font-size": "10px", "margin-bottom": "2px" }}>
-                <span style={{ color: key.active ? "var(--ctp-text)" : "var(--ctp-overlay0)" }}>
-                  {key.label} ({key.provider})
-                </span>
-                <span style={{ color: "var(--ctp-overlay0)" }}>{key.request_count} reqs</span>
-              </div>
-              {/* 5h bar */}
-              <div style={{ display: "flex", "align-items": "center", gap: "4px", "margin-bottom": "1px" }}>
-                <span style={{ "font-size": "8px", color: "var(--ctp-overlay0)", width: "20px" }}>5h</span>
-                <div style={{ flex: "1", height: "6px", background: "var(--ctp-surface0)", "border-radius": "3px", overflow: "hidden" }}>
-                  <div style={{
-                    width: `${Math.min(key.rate_limit_5h, 100)}%`,
-                    height: "100%",
-                    background: barColor(key.rate_limit_5h),
-                    "border-radius": "3px",
-                    transition: "width 300ms ease",
-                  }} />
+      <Show when={expanded()}>
+        <div style={{ display: "grid", gap: "6px", "margin-top": "6px" }}>
+          <div
+            data-testid="rate-limit-warning"
+            style={{
+              display: hasWarning() ? "block" : "none",
+              padding: "6px 8px",
+              background: "color-mix(in srgb, var(--ctp-red) 12%, transparent)",
+              border: "1px solid color-mix(in srgb, var(--ctp-red) 35%, transparent)",
+              "border-radius": "6px",
+              color: "var(--ctp-red)",
+              "font-size": "9px",
+              "font-weight": "700",
+            }}
+          >
+            High rate-limit utilization detected
+          </div>
+
+          <Show when={keys().length > 0} fallback={<div style={{ "font-size": "10px", color: "var(--ctp-overlay0)" }}>No API keys configured</div>}>
+            <For each={keys()}>
+              {(key) => (
+                <div style={{ "margin-bottom": "6px" }}>
+                  <div style={{ display: "flex", "justify-content": "space-between", "font-size": "10px", "margin-bottom": "2px" }}>
+                    <span style={{ color: key.active ? "var(--ctp-text)" : "var(--ctp-overlay0)" }}>
+                      {key.label} ({key.provider})
+                    </span>
+                    <span style={{ color: "var(--ctp-overlay0)" }}>{key.request_count} reqs</span>
+                  </div>
+                  <div
+                    data-testid="rate-limit-bar"
+                    style={{ display: "flex", "align-items": "center", gap: "4px", "margin-bottom": "1px" }}
+                  >
+                    <span style={{ "font-size": "8px", color: "var(--ctp-overlay0)", width: "20px" }}>5h</span>
+                    <div style={{ flex: "1", height: "6px", background: "var(--ctp-surface0)", "border-radius": "3px", overflow: "hidden" }}>
+                      <div style={{
+                        width: `${Math.min(key.rate_limit_5h, 100)}%`,
+                        height: "100%",
+                        background: barColor(key.rate_limit_5h),
+                        "border-radius": "3px",
+                        transition: "width 300ms ease",
+                      }} />
+                    </div>
+                    <span style={{ "font-size": "8px", color: barColor(key.rate_limit_5h), width: "28px", "text-align": "right" }}>
+                      {key.rate_limit_5h.toFixed(0)}%
+                    </span>
+                  </div>
+                  <div
+                    data-testid="rate-limit-bar"
+                    style={{ display: "flex", "align-items": "center", gap: "4px" }}
+                  >
+                    <span style={{ "font-size": "8px", color: "var(--ctp-overlay0)", width: "20px" }}>7d</span>
+                    <div style={{ flex: "1", height: "6px", background: "var(--ctp-surface0)", "border-radius": "3px", overflow: "hidden" }}>
+                      <div style={{
+                        width: `${Math.min(key.rate_limit_7d, 100)}%`,
+                        height: "100%",
+                        background: barColor(key.rate_limit_7d),
+                        "border-radius": "3px",
+                        transition: "width 300ms ease",
+                      }} />
+                    </div>
+                    <span style={{ "font-size": "8px", color: barColor(key.rate_limit_7d), width: "28px", "text-align": "right" }}>
+                      {key.rate_limit_7d.toFixed(0)}%
+                    </span>
+                  </div>
                 </div>
-                <span style={{ "font-size": "8px", color: barColor(key.rate_limit_5h), width: "28px", "text-align": "right" }}>
-                  {key.rate_limit_5h.toFixed(0)}%
-                </span>
-              </div>
-              {/* 7d bar */}
-              <div style={{ display: "flex", "align-items": "center", gap: "4px" }}>
-                <span style={{ "font-size": "8px", color: "var(--ctp-overlay0)", width: "20px" }}>7d</span>
-                <div style={{ flex: "1", height: "6px", background: "var(--ctp-surface0)", "border-radius": "3px", overflow: "hidden" }}>
-                  <div style={{
-                    width: `${Math.min(key.rate_limit_7d, 100)}%`,
-                    height: "100%",
-                    background: barColor(key.rate_limit_7d),
-                    "border-radius": "3px",
-                    transition: "width 300ms ease",
-                  }} />
-                </div>
-                <span style={{ "font-size": "8px", color: barColor(key.rate_limit_7d), width: "28px", "text-align": "right" }}>
-                  {key.rate_limit_7d.toFixed(0)}%
-                </span>
-              </div>
-            </div>
-          )}
-        </For>
+              )}
+            </For>
+          </Show>
+        </div>
       </Show>
     </div>
   );

--- a/frontend/src/components/network/RequestDetail.tsx
+++ b/frontend/src/components/network/RequestDetail.tsx
@@ -263,12 +263,38 @@ export default function RequestDetail(props: RequestDetailProps) {
     return null;
   });
 
+  const decodedResponseBody = createMemo(function () {
+    const body = props.request.responseBody;
+    const parsed = tryParseJson(body);
+    if (parsed) {
+      return {
+        text: JSON.stringify(parsed, null, 2),
+        isBase64: false,
+      };
+    }
+
+    const b64 = tryDecodeBase64(body);
+    if (b64) {
+      const innerParsed = tryParseJson(b64);
+      return {
+        text: innerParsed ? JSON.stringify(innerParsed, null, 2) : b64,
+        isBase64: true,
+      };
+    }
+
+    return {
+      text: body,
+      isBase64: false,
+    };
+  });
+
   const requestParsed = createMemo(function () {
     return parseRequestBody(props.request.requestBody);
   });
 
   return (
     <div
+      data-testid="request-detail"
       style={{
         display: "flex",
         "flex-direction": "column",
@@ -324,10 +350,7 @@ export default function RequestDetail(props: RequestDetailProps) {
                   <button
                     data-testid="copy-decoded-btn"
                     onClick={() => {
-                      const body = props.request.responseBody;
-                      const parsed = tryParseJson(body);
-                      const decoded = parsed ? JSON.stringify(parsed, null, 2) : (tryDecodeBase64(body) || body);
-                      void navigator.clipboard.writeText(decoded);
+                      void navigator.clipboard.writeText(decodedResponseBody().text);
                     }}
                     style={{
                       padding: "2px 8px",
@@ -342,18 +365,15 @@ export default function RequestDetail(props: RequestDetailProps) {
                     Copy decoded
                   </button>
                 </div>
-                <pre style={codeBlockStyle}>
-                  {(() => {
-                    const body = props.request.responseBody;
-                    const parsed = tryParseJson(body);
-                    if (parsed) return JSON.stringify(parsed, null, 2);
-                    const b64 = tryDecodeBase64(body);
-                    if (b64) {
-                      const innerParsed = tryParseJson(b64);
-                      return innerParsed ? JSON.stringify(innerParsed, null, 2) : b64;
-                    }
-                    return body;
-                  })()}
+                <pre
+                  data-testid={
+                    decodedResponseBody().isBase64
+                      ? "base64-decoded"
+                      : "decoded-body"
+                  }
+                  style={codeBlockStyle}
+                >
+                  {decodedResponseBody().text}
                 </pre>
               </div>
             }
@@ -412,6 +432,7 @@ export default function RequestDetail(props: RequestDetailProps) {
                   </span>
                 </Show>
                 <button
+                  data-testid="raw-decoded-toggle"
                   onClick={() => setShowRawResponse(true)}
                   style={{
                     "margin-left": "auto",

--- a/frontend/src/components/network/RewritePanel.tsx
+++ b/frontend/src/components/network/RewritePanel.tsx
@@ -1,5 +1,41 @@
-import { createSignal, Show, onMount } from "solid-js";
+import { createEffect, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { useSession } from "../../App";
+
+type RewriteModelOption = {
+  value: string;
+  label: string;
+};
+
+const CLAUDE_MODEL_OPTIONS: RewriteModelOption[] = [
+  { value: "claude-opus-4-6", label: "Opus 4.6" },
+  { value: "claude-sonnet-4-6", label: "Sonnet 4.6" },
+  { value: "claude-haiku-4-5-20251001", label: "Haiku 4.5" },
+];
+
+const CODEX_MODEL_OPTIONS: RewriteModelOption[] = [
+  { value: "gpt-5.4", label: "GPT-5.4" },
+  { value: "gpt-5.2-codex", label: "GPT-5.2 Codex" },
+  { value: "gpt-4o", label: "GPT-4o" },
+];
+
+const GEMINI_MODEL_OPTIONS: RewriteModelOption[] = [
+  { value: "gemini-3-flash-preview", label: "Gemini 3 Flash Preview" },
+  { value: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+  { value: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+  { value: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite" },
+];
+
+function modelOptionsFor(cliType?: "claude" | "codex" | "gemini"): RewriteModelOption[] {
+  switch (cliType) {
+    case "codex":
+      return CODEX_MODEL_OPTIONS;
+    case "gemini":
+      return GEMINI_MODEL_OPTIONS;
+    case "claude":
+    default:
+      return CLAUDE_MODEL_OPTIONS;
+  }
+}
 
 export default function RewritePanel() {
   const store = useSession();
@@ -8,11 +44,26 @@ export default function RewritePanel() {
   const [maxTokens, setMaxTokens] = createSignal<number | null>(null);
   const [thinkingType, setThinkingType] = createSignal("");
   const [pureMode, setPureMode] = createSignal(false);
+  const [stripSystemPrompt, setStripSystemPrompt] = createSignal(false);
+  const [stripTools, setStripTools] = createSignal(false);
+
+  function resetLocalState() {
+    setModelOverride("");
+    setTemperature(null);
+    setMaxTokens(null);
+    setThinkingType("");
+    setPureMode(false);
+    setStripSystemPrompt(false);
+    setStripTools(false);
+  }
 
   async function fetchConfig() {
     const base = store.state.httpApiUrl;
     const sid = store.state.activeSessionId;
-    if (!base || !sid) return;
+    if (!base || !sid) {
+      resetLocalState();
+      return;
+    }
     try {
       const res = await fetch(`${base}/api/proxy/rewrite/${sid}`);
       if (res.ok) {
@@ -22,6 +73,8 @@ export default function RewritePanel() {
         setMaxTokens(data.max_tokens ?? null);
         setThinkingType(data.thinking_type || "");
         setPureMode(data.pure_mode || false);
+        setStripSystemPrompt(data.strip_system_prompt || false);
+        setStripTools(data.strip_tools || false);
       }
     } catch { /* ignore */ }
   }
@@ -40,14 +93,44 @@ export default function RewritePanel() {
           max_tokens: maxTokens(),
           thinking_type: thinkingType() || null,
           pure_mode: pureMode(),
+          strip_system_prompt: stripSystemPrompt(),
+          strip_tools: stripTools(),
         }),
       });
     } catch { /* ignore */ }
   }
 
-  onMount(() => {
+  async function resetConfig() {
+    resetLocalState();
+    await saveConfig();
+  }
+
+  createEffect(() => {
+    void store.state.activeSessionId;
     void fetchConfig();
   });
+
+  onMount(() => {
+    const handler = (event: Event) => {
+      const sessionId = (event as CustomEvent<{ sessionId?: string }>).detail?.sessionId;
+      if (!sessionId || sessionId === store.state.activeSessionId) {
+        void fetchConfig();
+      }
+    };
+    window.addEventListener("noaide:rewrite-config-updated", handler);
+    onCleanup(() => window.removeEventListener("noaide:rewrite-config-updated", handler));
+  });
+
+  const activeCliType = () => store.activeSession()?.cliType ?? "claude";
+  const showThinkingType = () => activeCliType() === "claude";
+  const modelOptions = () => {
+    const current = modelOverride();
+    const options = modelOptionsFor(activeCliType());
+    if (!current || options.some((option) => option.value === current)) {
+      return options;
+    }
+    return [{ value: current, label: current }, ...options];
+  };
 
   const inputStyle = {
     padding: "3px 6px",
@@ -60,8 +143,9 @@ export default function RewritePanel() {
   };
 
   return (
-    <div
-      data-testid="rewrite-panel"
+    <section data-testid="rewrite-section">
+      <div
+        data-testid="rewrite-panel"
       style={{
         padding: "8px 12px",
         "border-top": "1px solid var(--ctp-surface0)",
@@ -79,20 +163,20 @@ export default function RewritePanel() {
         Request Rewrite
       </div>
 
-      <div style={{ display: "flex", gap: "8px", "flex-wrap": "wrap", "align-items": "center" }}>
+      <div style={{ display: "flex", gap: "8px", "flex-wrap": "wrap", "align-items": "center", "margin-bottom": "8px" }}>
         {/* Model Override */}
         <label style={{ "font-size": "10px", color: "var(--ctp-subtext0)" }}>
           Model:
           <select
-            data-testid="rewrite-model"
+            data-testid="model-select"
             value={modelOverride()}
             onChange={(e) => { setModelOverride(e.currentTarget.value); void saveConfig(); }}
             style={inputStyle}
           >
             <option value="">Default</option>
-            <option value="claude-opus-4-6">Opus 4.6</option>
-            <option value="claude-sonnet-4-6">Sonnet 4.6</option>
-            <option value="claude-haiku-4-5-20251001">Haiku 4.5</option>
+            <For each={modelOptions()}>
+              {(option) => <option value={option.value}>{option.label}</option>}
+            </For>
           </select>
         </label>
 
@@ -100,6 +184,7 @@ export default function RewritePanel() {
         <label style={{ "font-size": "10px", color: "var(--ctp-subtext0)" }}>
           Temp:
           <input
+            data-testid="temperature-input"
             type="number"
             min="0"
             max="2"
@@ -118,6 +203,7 @@ export default function RewritePanel() {
         <label style={{ "font-size": "10px", color: "var(--ctp-subtext0)" }}>
           Max:
           <input
+            data-testid="max-tokens-input"
             type="number"
             min="1"
             step="1024"
@@ -132,10 +218,11 @@ export default function RewritePanel() {
         </label>
 
         {/* Thinking Type */}
-        <Show when={modelOverride().includes("opus") || modelOverride().includes("sonnet") || !modelOverride()}>
+        <Show when={showThinkingType()}>
           <label style={{ "font-size": "10px", color: "var(--ctp-subtext0)" }}>
             Think:
             <select
+              data-testid="thinking-select"
               value={thinkingType()}
               onChange={(e) => { setThinkingType(e.currentTarget.value); void saveConfig(); }}
               style={inputStyle}
@@ -143,6 +230,7 @@ export default function RewritePanel() {
               <option value="">Default</option>
               <option value="enabled">Enabled</option>
               <option value="disabled">Disabled</option>
+              <option value="remove">Remove</option>
             </select>
           </label>
         </Show>
@@ -168,6 +256,73 @@ export default function RewritePanel() {
           Pure
         </label>
       </div>
-    </div>
+
+      <div style={{ display: "flex", gap: "10px", "flex-wrap": "wrap", "align-items": "center" }}>
+        <label
+          style={{
+            display: "flex",
+            "align-items": "center",
+            gap: "4px",
+            "font-size": "10px",
+            color: stripSystemPrompt() ? "var(--ctp-peach)" : "var(--ctp-overlay0)",
+            cursor: "pointer",
+          }}
+        >
+          <input
+            data-testid="strip-system-prompt"
+            type="checkbox"
+            checked={stripSystemPrompt()}
+            onChange={() => {
+              setStripSystemPrompt(!stripSystemPrompt());
+              void saveConfig();
+            }}
+            style={{ width: "12px", height: "12px" }}
+          />
+          Strip system
+        </label>
+
+        <label
+          style={{
+            display: "flex",
+            "align-items": "center",
+            gap: "4px",
+            "font-size": "10px",
+            color: stripTools() ? "var(--ctp-yellow)" : "var(--ctp-overlay0)",
+            cursor: "pointer",
+          }}
+        >
+          <input
+            data-testid="strip-tools"
+            type="checkbox"
+            checked={stripTools()}
+            onChange={() => {
+              setStripTools(!stripTools());
+              void saveConfig();
+            }}
+            style={{ width: "12px", height: "12px" }}
+          />
+          Strip tools
+        </label>
+
+        <button
+          type="button"
+          data-testid="rewrite-reset"
+          onClick={() => void resetConfig()}
+          style={{
+            padding: "3px 8px",
+            "font-size": "10px",
+            background: "var(--ctp-surface0)",
+            border: "1px solid var(--ctp-surface1)",
+            "border-radius": "4px",
+            color: "var(--ctp-subtext0)",
+            cursor: "pointer",
+            "font-weight": "600",
+          }}
+        >
+          Reset
+        </button>
+      </div>
+      </div>
+    </section>
   );
 }

--- a/frontend/src/components/network/RuleEditor.tsx
+++ b/frontend/src/components/network/RuleEditor.tsx
@@ -1,16 +1,44 @@
-import { createSignal, For, Show, onMount, onCleanup } from "solid-js";
-import { useSession } from "../../App";
+import { createSignal, For, Show, onMount, onCleanup, createEffect } from "solid-js";
 
 interface NetworkRule {
   id: string;
+  session_id?: string;
   domain_pattern?: string;
   category_filter?: string;
-  action: "allow" | "block" | { delay: { ms: number } };
+  action: RuleAction;
+  enabled?: boolean;
   priority: number;
 }
 
-export default function RuleEditor() {
-  const store = useSession();
+interface RuleEditorProps {
+  sessionId: string;
+  httpApiUrl: string;
+  refreshKey?: number;
+}
+
+type RuleAction =
+  | "allow"
+  | "block"
+  | { type: "allow" }
+  | { type: "block" }
+  | { type: "delay"; ms: number }
+  | { delay: { ms: number } };
+
+function actionType(action: RuleAction): "allow" | "block" | "delay" {
+  if (typeof action === "string") return action;
+  if ("type" in action) return action.type;
+  return "delay";
+}
+
+function actionLabel(action: RuleAction): string {
+  if (typeof action !== "string") {
+    if ("ms" in action) return `DELAY ${action.ms}ms`;
+    if ("delay" in action) return `DELAY ${action.delay.ms}ms`;
+  }
+  return actionType(action).toUpperCase();
+}
+
+export default function RuleEditor(props: RuleEditorProps) {
   const [rules, setRules] = createSignal<NetworkRule[]>([]);
   const [newDomain, setNewDomain] = createSignal("");
   const [newCategory, setNewCategory] = createSignal("");
@@ -18,32 +46,28 @@ export default function RuleEditor() {
   const [newPriority, _setNewPriority] = createSignal(50);
 
   async function fetchRules() {
-    const base = store.state.httpApiUrl;
-    const sid = store.state.activeSessionId;
-    if (!base || !sid) return;
     try {
-      const res = await fetch(`${base}/api/proxy/network-rules/${sid}`);
+      const res = await fetch(`${props.httpApiUrl}/api/proxy/network-rules/${props.sessionId}`);
       if (res.ok) {
         const data = await res.json();
-        setRules(data.rules || []);
+        setRules(Array.isArray(data) ? data : data.rules || []);
       }
     } catch { /* ignore */ }
   }
 
   async function addRule() {
-    const base = store.state.httpApiUrl;
-    const sid = store.state.activeSessionId;
-    if (!base || !sid) return;
     const body: Record<string, unknown> = {
-      session_id: sid,
-      action: newAction(),
+      id: "",
+      session_id: props.sessionId,
+      action: { type: newAction() },
+      enabled: true,
       priority: newPriority(),
     };
     if (newDomain()) body.domain_pattern = newDomain();
-    if (newCategory()) body.category_filter = newCategory();
+    if (newCategory()) body.category_filter = newCategory().toLowerCase();
 
     try {
-      await fetch(`${base}/api/proxy/network-rules`, {
+      await fetch(`${props.httpApiUrl}/api/proxy/network-rules/${props.sessionId}/rules`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
@@ -55,11 +79,8 @@ export default function RuleEditor() {
   }
 
   async function deleteRule(ruleId: string) {
-    const base = store.state.httpApiUrl;
-    const sid = store.state.activeSessionId;
-    if (!base || !sid) return;
     try {
-      await fetch(`${base}/api/proxy/network-rules/${sid}/${ruleId}`, {
+      await fetch(`${props.httpApiUrl}/api/proxy/network-rules/${props.sessionId}/rules/${ruleId}`, {
         method: "DELETE",
       });
       await fetchRules();
@@ -70,6 +91,18 @@ export default function RuleEditor() {
     fetchRules();
     const interval = setInterval(fetchRules, 5000);
     onCleanup(() => clearInterval(interval));
+  });
+
+  createEffect(() => {
+    props.sessionId;
+    props.httpApiUrl;
+    setRules([]);
+    void fetchRules();
+  });
+
+  createEffect(() => {
+    props.refreshKey;
+    void fetchRules();
   });
 
   return (
@@ -129,17 +162,15 @@ export default function RuleEditor() {
                     "font-size": "9px",
                     "font-weight": "600",
                     background:
-                      rule.action === "block"
+                      actionType(rule.action) === "block"
                         ? "var(--ctp-red)"
-                        : rule.action === "allow"
+                        : actionType(rule.action) === "allow"
                           ? "var(--ctp-green)"
                           : "var(--ctp-yellow)",
                     color: "var(--ctp-base)",
                   }}
                 >
-                  {typeof rule.action === "string"
-                    ? rule.action.toUpperCase()
-                    : `DELAY ${rule.action.delay.ms}ms`}
+                  {actionLabel(rule.action)}
                 </span>
                 <span style={{ color: "var(--ctp-text)", flex: "1" }}>
                   {rule.domain_pattern || rule.category_filter || "any"}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -139,6 +139,15 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
+    // Recovery: load persisted proxy configs (modes, inject, rewrite) from disk
+    noaide_server::proxy::persist::startup_cleanup();
+    noaide_server::proxy::persist::load_all_into_stores(
+        &proxy_state.proxy_modes,
+        &proxy_state.inject_store,
+        &proxy_state.rewrite_store,
+        &proxy_state.network_rules,
+    );
+
     let proxy_port: u16 = std::env::var("NOAIDE_PROXY_PORT")
         .ok()
         .and_then(|v| v.parse().ok())
@@ -3687,6 +3696,7 @@ async fn api_get_proxy_config(
         mode: state.proxy.proxy_modes.get(&session_id),
         inject: state.proxy.inject_store.get(&session_id),
         rewrite: state.proxy.rewrite_store.get(&session_id),
+        rules: state.proxy.network_rules.get_rules(&session_id),
     };
     axum::Json(config)
 }
@@ -3705,6 +3715,12 @@ async fn api_set_proxy_config(
         .proxy
         .rewrite_store
         .set(session_id.clone(), config.rewrite.clone());
+    if !config.rules.is_empty() {
+        state
+            .proxy
+            .network_rules
+            .set_rules(&session_id, config.rules.clone());
+    }
     // Persist to disk (debounced)
     noaide_server::proxy::persist::schedule_save(session_id, config);
     axum::Json(serde_json::json!({ "ok": true }))

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -146,7 +146,9 @@ async fn main() -> anyhow::Result<()> {
         &proxy_state.inject_store,
         &proxy_state.rewrite_store,
         &proxy_state.network_rules,
-    );
+        &proxy_state.intercept_modes,
+    )
+    .await;
 
     let proxy_port: u16 = std::env::var("NOAIDE_PROXY_PORT")
         .ok()
@@ -199,6 +201,16 @@ async fn main() -> anyhow::Result<()> {
             "restored session→plan mappings from previous run"
         );
         drop(mapping);
+    }
+
+    match noaide_server::proxy::keys::load_from_disk(&proxy_state.key_store) {
+        Ok(loaded) if loaded > 0 => {
+            info!(loaded = loaded, "restored api keys from disk");
+        }
+        Ok(_) => {}
+        Err(e) => {
+            warn!(error = %e, "failed to restore api keys from disk");
+        }
     }
 
     let app_state = AppState {
@@ -317,7 +329,10 @@ async fn main() -> anyhow::Result<()> {
         )
         .route("/api/proxy/presets", get(api_list_presets))
         .route("/api/proxy/keys", get(api_list_keys).post(api_add_key))
-        .route("/api/proxy/keys/{key_id}", delete(api_delete_key))
+        .route(
+            "/api/proxy/keys/{key_id}",
+            delete(api_delete_key).put(api_update_key),
+        )
         .route("/api/proxy/keys/status", get(api_keys_status))
         .route("/api/proxy/audit", get(api_get_audit))
         .route("/api/proxy/audit/export", get(api_export_audit))
@@ -444,6 +459,20 @@ async fn main() -> anyhow::Result<()> {
         if script_path.exists() {
             tokio::spawn(async move {
                 loop {
+                    match std::net::TcpListener::bind(("0.0.0.0", whisper_port)) {
+                        Ok(listener) => drop(listener),
+                        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                            warn!(port = whisper_port, "whisper sidecar port already in use; skipping spawn");
+                            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                            continue;
+                        }
+                        Err(e) => {
+                            warn!(error = %e, port = whisper_port, "failed to probe whisper sidecar port");
+                            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                            continue;
+                        }
+                    }
+
                     info!(port = whisper_port, "spawning whisper sidecar");
                     let result = tokio::process::Command::new(&venv_python)
                         .arg(&script_path)
@@ -2166,17 +2195,33 @@ async fn api_send_message(
         let session_id = noaide_server::session::SessionId(uuid);
         let mgr = state.session_manager.read().await;
         if let Some(session) = mgr.get(&session_id) {
-            // Send text and CR separately. Ink-based TUIs (Gemini CLI) parse
-            // raw PTY input in chunks — if text and \r arrive in the same
-            // read() call, Ink treats \r as a newline character in the text
-            // field rather than as a Return key press that triggers submit.
-            // Splitting the write with a short delay ensures the TUI processes
-            // the text first (onChange) and then handles \r as Return (onSubmit).
-            // This also works correctly for Claude CLI which handles both forms.
+            let cli_type = {
+                let types = state.session_cli_types.read().await;
+                types.get(&uuid).copied()
+            };
+
             let send_result = async {
-                session.send_input(&body.text).await?;
-                tokio::time::sleep(std::time::Duration::from_millis(30)).await;
-                session.send_input("\r").await
+                if cli_type == Some(noaide_server::discovery::scanner::CliType::Gemini) {
+                    // Gemini CLI treats multi-character PTY writes as an untrusted
+                    // paste. In that mode Enter is downgraded to newline instead
+                    // of submit, so the prompt just grows a blank line and never
+                    // issues generateContent/streamGenerateContent. Type each
+                    // character as an individual keypress to avoid paste mode.
+                    for ch in body.text.chars() {
+                        let mut buf = [0u8; 4];
+                        session.send_input(ch.encode_utf8(&mut buf)).await?;
+                        tokio::time::sleep(std::time::Duration::from_millis(15)).await;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+                    session.send_input("\r").await
+                } else {
+                    // Send text and CR separately. Ink-based TUIs parse raw PTY
+                    // input in chunks — if text and \r arrive in the same read(),
+                    // \r can end up as literal newline text instead of submit.
+                    session.send_input(&body.text).await?;
+                    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+                    session.send_input("\r").await
+                }
             }
             .await;
 
@@ -2831,6 +2876,18 @@ fn extract_request_preview(body: &str) -> String {
     }
 }
 
+/// Decode intercepted request/response bodies for display when the original
+/// transport used body compression (for example Codex `content-encoding: zstd`).
+fn render_intercept_body(body: &[u8], headers: &[(String, String)]) -> String {
+    let decoded = headers
+        .iter()
+        .any(|(k, v)| k.eq_ignore_ascii_case("content-encoding") && v.contains("zstd"))
+        .then(|| zstd::stream::decode_all(body).ok())
+        .flatten();
+    let display = decoded.as_deref().unwrap_or(body);
+    noaide_server::proxy::mitm::redact(&String::from_utf8_lossy(display))
+}
+
 /// Truncate a string to max_len chars, appending "..." if truncated.
 fn truncate_preview(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
@@ -2936,63 +2993,7 @@ async fn api_set_intercept_mode(
     Path(session_id): Path<String>,
     axum::Json(body): axum::Json<SetInterceptModeRequest>,
 ) -> axum::Json<serde_json::Value> {
-    state
-        .proxy
-        .intercept_modes
-        .write()
-        .await
-        .insert(session_id.clone(), body.mode);
-
-    // Auto-forward all pending requests when switching to Auto
-    if body.mode == noaide_server::proxy::InterceptMode::Auto {
-        let mut pending = state.proxy.pending_intercepts.write().await;
-        let session_ids: Vec<String> = pending
-            .iter()
-            .filter(|(_, p)| p.session_id.as_deref() == Some(&session_id))
-            .map(|(id, _)| id.clone())
-            .collect();
-
-        let mut forwarded = 0;
-        for id in session_ids {
-            if let Some(p) = pending.remove(&id) {
-                let _ = p
-                    .decision_tx
-                    .send(noaide_server::proxy::InterceptDecision::Forward {
-                        modified_body: None,
-                        modified_headers: None,
-                    });
-                forwarded += 1;
-            }
-        }
-
-        // Also auto-forward all pending response intercepts for this session
-        let mut pending_resp = state.proxy.pending_response_intercepts.write().await;
-        let resp_ids: Vec<String> = pending_resp
-            .iter()
-            .filter(|(_, p)| p.session_id.as_deref() == Some(&session_id))
-            .map(|(id, _)| id.clone())
-            .collect();
-
-        let mut forwarded_responses = 0;
-        for id in resp_ids {
-            if let Some(p) = pending_resp.remove(&id) {
-                let _ = p
-                    .decision_tx
-                    .send(noaide_server::proxy::InterceptDecision::Forward {
-                        modified_body: None,
-                        modified_headers: None,
-                    });
-                forwarded_responses += 1;
-            }
-        }
-
-        info!(
-            session = %session_id,
-            forwarded_requests = forwarded,
-            forwarded_responses,
-            "switched to auto mode, forwarded all pending"
-        );
-    }
+    set_session_intercept_mode(&state, &session_id, body.mode).await;
 
     axum::Json(serde_json::json!({
         "ok": true,
@@ -3011,8 +3012,7 @@ async fn api_get_pending_intercepts(
         .filter(|p| p.session_id.as_deref() == Some(&session_id))
         .map(|p| {
             // Redact request body for display
-            let body_preview =
-                noaide_server::proxy::mitm::redact(&String::from_utf8_lossy(&p.request_body));
+            let body_preview = render_intercept_body(&p.request_body, &p.request_headers);
             // Check if caller (CLI) already disconnected (oneshot receiver dropped)
             let disconnected = p.decision_tx.is_closed();
             serde_json::json!({
@@ -3053,8 +3053,7 @@ async fn api_get_pending_body(
             axum::Json(serde_json::json!({"error": "session mismatch"})),
         );
     }
-    let body =
-        noaide_server::proxy::mitm::redact(&String::from_utf8_lossy(&intercept.request_body));
+    let body = render_intercept_body(&intercept.request_body, &intercept.request_headers);
     (
         axum::http::StatusCode::OK,
         axum::Json(serde_json::json!({"body": body})),
@@ -3581,6 +3580,10 @@ async fn api_set_network_rules(
     axum::Json(rules): axum::Json<Vec<noaide_server::proxy::NetworkRule>>,
 ) -> StatusCode {
     state.proxy.network_rules.set_rules(&session_id, rules);
+    noaide_server::proxy::persist::schedule_save(
+        session_id.clone(),
+        build_proxy_config_snapshot(&state, &session_id),
+    );
     StatusCode::OK
 }
 
@@ -3591,6 +3594,10 @@ async fn api_add_network_rule(
     axum::Json(rule): axum::Json<noaide_server::proxy::NetworkRule>,
 ) -> (StatusCode, axum::Json<serde_json::Value>) {
     let id = state.proxy.network_rules.add_rule(&session_id, rule);
+    noaide_server::proxy::persist::schedule_save(
+        session_id.clone(),
+        build_proxy_config_snapshot(&state, &session_id),
+    );
     (
         StatusCode::CREATED,
         axum::Json(serde_json::json!({ "id": id })),
@@ -3603,6 +3610,10 @@ async fn api_delete_network_rule(
     axum::extract::Path((session_id, rule_id)): axum::extract::Path<(String, String)>,
 ) -> StatusCode {
     if state.proxy.network_rules.remove_rule(&session_id, &rule_id) {
+        noaide_server::proxy::persist::schedule_save(
+            session_id.clone(),
+            build_proxy_config_snapshot(&state, &session_id),
+        );
         StatusCode::NO_CONTENT
     } else {
         StatusCode::NOT_FOUND
@@ -3637,6 +3648,10 @@ async fn api_quick_block_domain(
         priority: 50,
     };
     let id = state.proxy.network_rules.add_rule(&session_id, rule);
+    noaide_server::proxy::persist::schedule_save(
+        session_id.clone(),
+        build_proxy_config_snapshot(&state, &session_id),
+    );
     (
         StatusCode::CREATED,
         axum::Json(serde_json::json!({ "id": id })),
@@ -3658,12 +3673,111 @@ struct SetModeRequest {
     mode: noaide_server::proxy::modes::ProxyMode,
 }
 
+fn build_proxy_config_snapshot(
+    state: &AppState,
+    session_id: &str,
+) -> noaide_server::proxy::persist::ProxyConfig {
+    noaide_server::proxy::persist::ProxyConfig {
+        mode: state.proxy.proxy_modes.get(session_id),
+        inject: state.proxy.inject_store.get(session_id),
+        rewrite: state.proxy.rewrite_store.get(session_id),
+        rules: state.proxy.network_rules.get_rules(session_id),
+    }
+}
+
+fn intercept_mode_for_proxy_mode(
+    mode: noaide_server::proxy::modes::ProxyMode,
+) -> noaide_server::proxy::InterceptMode {
+    match mode {
+        noaide_server::proxy::modes::ProxyMode::Manual => {
+            noaide_server::proxy::InterceptMode::Manual
+        }
+        _ => noaide_server::proxy::InterceptMode::Auto,
+    }
+}
+
+async fn set_session_intercept_mode(
+    state: &AppState,
+    session_id: &str,
+    mode: noaide_server::proxy::InterceptMode,
+) {
+    state
+        .proxy
+        .intercept_modes
+        .write()
+        .await
+        .insert(session_id.to_string(), mode);
+
+    if mode != noaide_server::proxy::InterceptMode::Auto {
+        return;
+    }
+
+    // Auto-forward all pending requests when switching to Auto.
+    let mut pending = state.proxy.pending_intercepts.write().await;
+    let request_ids: Vec<String> = pending
+        .iter()
+        .filter(|(_, p)| p.session_id.as_deref() == Some(session_id))
+        .map(|(id, _)| id.clone())
+        .collect();
+
+    let mut forwarded_requests = 0;
+    for id in request_ids {
+        if let Some(p) = pending.remove(&id) {
+            let _ = p
+                .decision_tx
+                .send(noaide_server::proxy::InterceptDecision::Forward {
+                    modified_body: None,
+                    modified_headers: None,
+                });
+            forwarded_requests += 1;
+        }
+    }
+
+    // Also auto-forward all pending response intercepts for this session.
+    let mut pending_responses = state.proxy.pending_response_intercepts.write().await;
+    let response_ids: Vec<String> = pending_responses
+        .iter()
+        .filter(|(_, p)| p.session_id.as_deref() == Some(session_id))
+        .map(|(id, _)| id.clone())
+        .collect();
+
+    let mut forwarded_responses = 0;
+    for id in response_ids {
+        if let Some(p) = pending_responses.remove(&id) {
+            let _ = p
+                .decision_tx
+                .send(noaide_server::proxy::InterceptDecision::Forward {
+                    modified_body: None,
+                    modified_headers: None,
+                });
+            forwarded_responses += 1;
+        }
+    }
+
+    info!(
+        session = %session_id,
+        forwarded_requests,
+        forwarded_responses,
+        "switched intercept mode to auto, forwarded all pending"
+    );
+}
+
 async fn api_set_proxy_mode(
     State(state): State<AppState>,
     axum::extract::Path(session_id): axum::extract::Path<String>,
     axum::Json(body): axum::Json<SetModeRequest>,
 ) -> axum::Json<serde_json::Value> {
-    state.proxy.proxy_modes.set(session_id, body.mode);
+    state.proxy.proxy_modes.set(session_id.clone(), body.mode);
+    set_session_intercept_mode(
+        &state,
+        &session_id,
+        intercept_mode_for_proxy_mode(body.mode),
+    )
+    .await;
+    noaide_server::proxy::persist::schedule_save(
+        session_id.clone(),
+        build_proxy_config_snapshot(&state, &session_id),
+    );
     axum::Json(serde_json::json!({ "ok": true }))
 }
 
@@ -3681,7 +3795,11 @@ async fn api_set_inject_config(
     axum::extract::Path(session_id): axum::extract::Path<String>,
     axum::Json(config): axum::Json<noaide_server::proxy::inject::InjectConfig>,
 ) -> axum::Json<serde_json::Value> {
-    state.proxy.inject_store.set(session_id, config);
+    state.proxy.inject_store.set(session_id.clone(), config);
+    noaide_server::proxy::persist::schedule_save(
+        session_id.clone(),
+        build_proxy_config_snapshot(&state, &session_id),
+    );
     axum::Json(serde_json::json!({ "ok": true }))
 }
 
@@ -3691,14 +3809,7 @@ async fn api_get_proxy_config(
     State(state): State<AppState>,
     axum::extract::Path(session_id): axum::extract::Path<String>,
 ) -> axum::Json<noaide_server::proxy::persist::ProxyConfig> {
-    // Build config from current in-memory state
-    let config = noaide_server::proxy::persist::ProxyConfig {
-        mode: state.proxy.proxy_modes.get(&session_id),
-        inject: state.proxy.inject_store.get(&session_id),
-        rewrite: state.proxy.rewrite_store.get(&session_id),
-        rules: state.proxy.network_rules.get_rules(&session_id),
-    };
-    axum::Json(config)
+    axum::Json(build_proxy_config_snapshot(&state, &session_id))
 }
 
 async fn api_set_proxy_config(
@@ -3707,6 +3818,12 @@ async fn api_set_proxy_config(
     axum::Json(config): axum::Json<noaide_server::proxy::persist::ProxyConfig>,
 ) -> axum::Json<serde_json::Value> {
     state.proxy.proxy_modes.set(session_id.clone(), config.mode);
+    set_session_intercept_mode(
+        &state,
+        &session_id,
+        intercept_mode_for_proxy_mode(config.mode),
+    )
+    .await;
     state
         .proxy
         .inject_store
@@ -3715,12 +3832,10 @@ async fn api_set_proxy_config(
         .proxy
         .rewrite_store
         .set(session_id.clone(), config.rewrite.clone());
-    if !config.rules.is_empty() {
-        state
-            .proxy
-            .network_rules
-            .set_rules(&session_id, config.rules.clone());
-    }
+    state
+        .proxy
+        .network_rules
+        .set_rules(&session_id, config.rules.clone());
     // Persist to disk (debounced)
     noaide_server::proxy::persist::schedule_save(session_id, config);
     axum::Json(serde_json::json!({ "ok": true }))
@@ -3806,6 +3921,25 @@ struct AddKeyRequest {
     label: String,
 }
 
+#[derive(serde::Deserialize)]
+struct UpdateKeyRequest {
+    active: bool,
+}
+
+fn mask_key_value(encrypted: &str) -> String {
+    match noaide_server::proxy::keys::decrypt_key(encrypted) {
+        Ok(plaintext) => {
+            let prefix: String = plaintext.chars().take(7).collect();
+            if prefix.is_empty() {
+                "***".to_string()
+            } else {
+                format!("{prefix}***")
+            }
+        }
+        Err(_) => "***".to_string(),
+    }
+}
+
 async fn api_list_keys(State(state): State<AppState>) -> axum::Json<serde_json::Value> {
     let keys: Vec<serde_json::Value> = state
         .proxy
@@ -3817,6 +3951,7 @@ async fn api_list_keys(State(state): State<AppState>) -> axum::Json<serde_json::
                 "id": k.id,
                 "provider": k.provider,
                 "label": k.label,
+                "masked_value": mask_key_value(&k.key_encrypted),
                 "active": k.active,
                 "rate_limit_5h": k.rate_limit_5h,
                 "rate_limit_7d": k.rate_limit_7d,
@@ -3836,6 +3971,9 @@ async fn api_add_key(
         .proxy
         .key_store
         .add_key(&body.provider, &body.key, &body.label);
+    if let Err(e) = noaide_server::proxy::keys::save_to_disk(&state.proxy.key_store) {
+        warn!(error = %e, key_id = %id, "failed to persist api keys after add");
+    }
     (
         StatusCode::CREATED,
         axum::Json(serde_json::json!({ "id": id })),
@@ -3847,7 +3985,26 @@ async fn api_delete_key(
     axum::extract::Path(key_id): axum::extract::Path<String>,
 ) -> axum::Json<serde_json::Value> {
     let removed = state.proxy.key_store.remove_key(&key_id);
+    if removed
+        && let Err(e) = noaide_server::proxy::keys::save_to_disk(&state.proxy.key_store)
+    {
+        warn!(error = %e, key_id = %key_id, "failed to persist api keys after delete");
+    }
     axum::Json(serde_json::json!({ "removed": removed }))
+}
+
+async fn api_update_key(
+    State(state): State<AppState>,
+    axum::extract::Path(key_id): axum::extract::Path<String>,
+    axum::Json(body): axum::Json<UpdateKeyRequest>,
+) -> axum::Json<serde_json::Value> {
+    let updated = state.proxy.key_store.set_active(&key_id, body.active);
+    if updated
+        && let Err(e) = noaide_server::proxy::keys::save_to_disk(&state.proxy.key_store)
+    {
+        warn!(error = %e, key_id = %key_id, active = body.active, "failed to persist api keys after update");
+    }
+    axum::Json(serde_json::json!({ "updated": updated }))
 }
 
 async fn api_keys_status(State(state): State<AppState>) -> axum::Json<serde_json::Value> {
@@ -3868,7 +4025,11 @@ async fn api_set_rewrite_config(
     axum::extract::Path(session_id): axum::extract::Path<String>,
     axum::Json(config): axum::Json<noaide_server::proxy::rewrite::RewriteConfig>,
 ) -> axum::Json<serde_json::Value> {
-    state.proxy.rewrite_store.set(session_id, config);
+    state.proxy.rewrite_store.set(session_id.clone(), config);
+    noaide_server::proxy::persist::schedule_save(
+        session_id.clone(),
+        build_proxy_config_snapshot(&state, &session_id),
+    );
     axum::Json(serde_json::json!({ "ok": true }))
 }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -462,7 +462,10 @@ async fn main() -> anyhow::Result<()> {
                     match std::net::TcpListener::bind(("0.0.0.0", whisper_port)) {
                         Ok(listener) => drop(listener),
                         Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
-                            warn!(port = whisper_port, "whisper sidecar port already in use; skipping spawn");
+                            warn!(
+                                port = whisper_port,
+                                "whisper sidecar port already in use; skipping spawn"
+                            );
                             tokio::time::sleep(std::time::Duration::from_secs(10)).await;
                             continue;
                         }
@@ -3985,9 +3988,7 @@ async fn api_delete_key(
     axum::extract::Path(key_id): axum::extract::Path<String>,
 ) -> axum::Json<serde_json::Value> {
     let removed = state.proxy.key_store.remove_key(&key_id);
-    if removed
-        && let Err(e) = noaide_server::proxy::keys::save_to_disk(&state.proxy.key_store)
-    {
+    if removed && let Err(e) = noaide_server::proxy::keys::save_to_disk(&state.proxy.key_store) {
         warn!(error = %e, key_id = %key_id, "failed to persist api keys after delete");
     }
     axum::Json(serde_json::json!({ "removed": removed }))
@@ -3999,9 +4000,7 @@ async fn api_update_key(
     axum::Json(body): axum::Json<UpdateKeyRequest>,
 ) -> axum::Json<serde_json::Value> {
     let updated = state.proxy.key_store.set_active(&key_id, body.active);
-    if updated
-        && let Err(e) = noaide_server::proxy::keys::save_to_disk(&state.proxy.key_store)
-    {
+    if updated && let Err(e) = noaide_server::proxy::keys::save_to_disk(&state.proxy.key_store) {
         warn!(error = %e, key_id = %key_id, active = body.active, "failed to persist api keys after update");
     }
     axum::Json(serde_json::json!({ "updated": updated }))

--- a/server/src/proxy/classify.rs
+++ b/server/src/proxy/classify.rs
@@ -1,6 +1,6 @@
-//! Traffic classification for CONNECT MITM proxy.
+//! Traffic classification for proxy traffic.
 //!
-//! Classifies network traffic by domain into categories
+//! Classifies reverse-proxy and CONNECT traffic into categories
 //! (Api, Telemetry, Auth, Update, Git, Unknown) for the
 //! network rules engine and Network Tab display.
 
@@ -62,6 +62,20 @@ static RULES: &[(&str, TrafficCategory)] = &[
     ("chatgpt.com", TrafficCategory::Api),
 ];
 
+/// Codex ChatGPT-backend analytics endpoint.
+///
+/// Upstream Codex currently posts analytics events to:
+/// `https://chatgpt.com/backend-api/codex/analytics-events/events`
+const CODEX_CHATGPT_ANALYTICS_PATH: &str = "/backend-api/codex/analytics-events/events";
+
+fn strip_port(host: &str) -> &str {
+    host.split(':').next().unwrap_or(host)
+}
+
+fn is_chatgpt_telemetry_path(domain: &str, path: &str) -> bool {
+    domain == "chatgpt.com" && path.starts_with(CODEX_CHATGPT_ANALYTICS_PATH)
+}
+
 /// Classify a domain (host without port) into a traffic category.
 ///
 /// Matching rules:
@@ -70,8 +84,20 @@ static RULES: &[(&str, TrafficCategory)] = &[
 ///
 /// Returns `Unknown` if no rule matches.
 pub fn classify_domain(host: &str) -> TrafficCategory {
-    // Strip port if present (e.g. "github.com:443" → "github.com")
-    let domain = host.split(':').next().unwrap_or(host);
+    classify_request(host, "")
+}
+
+/// Classify a request by host + path.
+///
+/// Some traffic needs path-aware classification. In particular, Codex emits
+/// analytics traffic on `chatgpt.com`, which would otherwise be lumped into
+/// the general ChatGPT API bucket.
+pub fn classify_request(host: &str, path: &str) -> TrafficCategory {
+    let domain = strip_port(host);
+
+    if is_chatgpt_telemetry_path(domain, path) {
+        return TrafficCategory::Telemetry;
+    }
 
     for &(pattern, category) in RULES {
         if domain == pattern {
@@ -85,6 +111,20 @@ pub fn classify_domain(host: &str) -> TrafficCategory {
     }
 
     TrafficCategory::Unknown
+}
+
+/// Classify an absolute URL into a traffic category.
+pub fn classify_url(url: &str) -> TrafficCategory {
+    let without_scheme = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+        .unwrap_or(url);
+
+    let Some(path_start) = without_scheme.find('/') else {
+        return classify_request(without_scheme, "");
+    };
+
+    classify_request(&without_scheme[..path_start], &without_scheme[path_start..])
 }
 
 #[cfg(test)]
@@ -180,6 +220,30 @@ mod tests {
     fn test_chatgpt_is_api() {
         // chatgpt.com (without subdomain) is Api, NOT telemetry
         assert_eq!(classify_domain("chatgpt.com"), TrafficCategory::Api);
+    }
+
+    #[test]
+    fn test_chatgpt_analytics_events_are_telemetry() {
+        assert_eq!(
+            classify_request("chatgpt.com", "/backend-api/codex/analytics-events/events"),
+            TrafficCategory::Telemetry
+        );
+    }
+
+    #[test]
+    fn test_chatgpt_regular_backend_api_remains_api() {
+        assert_eq!(
+            classify_request("chatgpt.com", "/backend-api/codex/responses"),
+            TrafficCategory::Api
+        );
+    }
+
+    #[test]
+    fn test_chatgpt_analytics_url_with_port_is_telemetry() {
+        assert_eq!(
+            classify_url("https://chatgpt.com:443/backend-api/codex/analytics-events/events"),
+            TrafficCategory::Telemetry
+        );
     }
 
     #[test]

--- a/server/src/proxy/handler.rs
+++ b/server/src/proxy/handler.rs
@@ -2254,18 +2254,24 @@ mod tests {
 
         let mut anthropic_headers = vec![("authorization".to_string(), "Bearer stale".to_string())];
         apply_rotated_api_key(&mut anthropic_headers, ApiProvider::Anthropic, &store);
-        assert!(anthropic_headers
-            .iter()
-            .any(|(name, value)| name == "x-api-key" && value == "sk-ant-test-1"));
-        assert!(!anthropic_headers
-            .iter()
-            .any(|(name, _)| name == "authorization"));
+        assert!(
+            anthropic_headers
+                .iter()
+                .any(|(name, value)| name == "x-api-key" && value == "sk-ant-test-1")
+        );
+        assert!(
+            !anthropic_headers
+                .iter()
+                .any(|(name, _)| name == "authorization")
+        );
 
         let mut openai_headers = vec![("authorization".to_string(), "Bearer stale".to_string())];
         apply_rotated_api_key(&mut openai_headers, ApiProvider::OpenAI, &store);
-        assert!(openai_headers
-            .iter()
-            .any(|(name, value)| name == "authorization" && value == "Bearer sk-proj-test-1"));
+        assert!(
+            openai_headers
+                .iter()
+                .any(|(name, value)| name == "authorization" && value == "Bearer sk-proj-test-1")
+        );
 
         let mut google_headers = vec![
             (
@@ -2278,9 +2284,11 @@ mod tests {
         assert!(google_headers.iter().any(|(name, value)| {
             name == "x-goog-api-key" && value == "AIzaSyB1234567890abcdefghijklmnopqrst"
         }));
-        assert!(!google_headers
-            .iter()
-            .any(|(name, _)| name == "authorization"));
+        assert!(
+            !google_headers
+                .iter()
+                .any(|(name, _)| name == "authorization")
+        );
     }
 
     #[tokio::test]

--- a/server/src/proxy/handler.rs
+++ b/server/src/proxy/handler.rs
@@ -968,7 +968,7 @@ pub async fn proxy_handler(
             .increment(1);
             metrics::histogram!("proxy_latency_ms",
                 "method" => log_entry.method.clone(),
-                "provider" => provider_label,
+                "provider" => provider_label.clone(),
             )
             .record(log_entry.latency_ms as f64);
 
@@ -979,7 +979,33 @@ pub async fn proxy_handler(
                 }
                 cap.push_back(log_entry.clone());
             }
-            let _ = log_state.event_tx.send(log_entry);
+            let _ = log_state.event_tx.send(log_entry.clone());
+
+            // ── Audit Log: extract tokens from streaming response ──
+            {
+                let response_str = &log_entry.response_body;
+                let (model, input_tokens, output_tokens, cache_creation, cache_read) =
+                    super::audit::extract_tokens(response_str);
+                if input_tokens > 0 || output_tokens > 0 {
+                    let cost = super::audit::calculate_cost(&model, input_tokens, output_tokens);
+                    let audit_entry = super::audit::AuditEntry {
+                        id: log_entry.id.clone(),
+                        session_id: log_entry.session_id.clone(),
+                        method: log_entry.method.clone(),
+                        url: log_entry.url.clone(),
+                        model,
+                        provider: provider_label,
+                        input_tokens,
+                        output_tokens,
+                        cache_creation_tokens: cache_creation,
+                        cache_read_tokens: cache_read,
+                        cost_usd: cost,
+                        timestamp: log_entry.timestamp,
+                        latency_ms: log_entry.latency_ms,
+                    };
+                    super::audit::append_entry(&audit_entry);
+                }
+            }
         });
 
         // Build streaming response back to caller

--- a/server/src/proxy/handler.rs
+++ b/server/src/proxy/handler.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, VecDeque};
+use std::io::Cursor;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -82,15 +83,92 @@ impl<S: tokio::io::AsyncWrite + Unpin> tokio::io::AsyncWrite for PrefixedIo<S> {
 /// Try to decompress a zstd-encoded request body for logging.
 /// Codex CLI sends `content-encoding: zstd` on request bodies.
 /// Original compressed bytes are still forwarded to upstream unchanged.
-fn try_decompress_request(body: &[u8], headers: &[(String, String)]) -> Option<Vec<u8>> {
-    let has_zstd = headers
+fn request_uses_zstd(headers: &[(String, String)]) -> bool {
+    headers
         .iter()
-        .any(|(k, v)| k == "content-encoding" && v.contains("zstd"));
-    if has_zstd {
-        zstd::stream::decode_all(body).ok()
+        .any(|(k, v)| k.eq_ignore_ascii_case("content-encoding") && v.contains("zstd"))
+}
+
+fn try_decompress_request(body: &[u8], headers: &[(String, String)]) -> Option<Vec<u8>> {
+    if request_uses_zstd(headers) {
+        zstd::stream::decode_all(Cursor::new(body)).ok()
     } else {
         None
     }
+}
+
+fn try_recompress_request(body: &[u8], headers: &[(String, String)]) -> Option<Vec<u8>> {
+    if request_uses_zstd(headers) {
+        zstd::stream::encode_all(Cursor::new(body), 0).ok()
+    } else {
+        Some(body.to_vec())
+    }
+}
+
+fn apply_forward_headers(
+    mut builder: reqwest::RequestBuilder,
+    headers: &[(String, String)],
+) -> reqwest::RequestBuilder {
+    for (name_str, value_str) in headers {
+        if name_str.eq_ignore_ascii_case("host")
+            || name_str.eq_ignore_ascii_case("connection")
+            || name_str.eq_ignore_ascii_case("transfer-encoding")
+            || name_str.eq_ignore_ascii_case("accept-encoding")
+            || name_str.eq_ignore_ascii_case("content-length")
+        {
+            continue;
+        }
+
+        let Ok(name) = reqwest::header::HeaderName::from_bytes(name_str.as_bytes()) else {
+            warn!(header = %name_str, "skipping invalid request header name");
+            continue;
+        };
+        let Ok(value) = reqwest::header::HeaderValue::from_str(value_str) else {
+            warn!(header = %name_str, "skipping invalid request header value");
+            continue;
+        };
+        builder = builder.header(name, value);
+    }
+    builder
+}
+
+fn rotated_key_header(provider: ApiProvider) -> (&'static str, bool) {
+    match provider {
+        ApiProvider::Anthropic => ("x-api-key", false),
+        ApiProvider::Google | ApiProvider::GoogleCodeAssist => ("x-goog-api-key", false),
+        ApiProvider::OpenAI | ApiProvider::ChatGPT => ("authorization", true),
+    }
+}
+
+fn apply_rotated_api_key(
+    headers: &mut Vec<(String, String)>,
+    provider: ApiProvider,
+    key_store: &super::keys::KeyStore,
+) {
+    if !key_store.has_active_keys(provider.label()) {
+        return;
+    }
+
+    let Some((_key_id, plaintext_key)) = key_store.select_key(provider.label()) else {
+        return;
+    };
+
+    let (header_name, use_bearer_prefix) = rotated_key_header(provider);
+    let header_value = if use_bearer_prefix {
+        format!("Bearer {plaintext_key}")
+    } else {
+        plaintext_key
+    };
+
+    headers.retain(|(name, _)| {
+        !name.eq_ignore_ascii_case(header_name)
+            && !(provider == ApiProvider::Anthropic && name.eq_ignore_ascii_case("authorization"))
+            && !(matches!(
+                provider,
+                ApiProvider::Google | ApiProvider::GoogleCodeAssist
+            ) && name.eq_ignore_ascii_case("authorization"))
+    });
+    headers.push((header_name.to_string(), header_value));
 }
 
 /// Maximum number of captured requests kept in memory
@@ -304,6 +382,62 @@ pub async fn proxy_handler(
     let base_url = provider.base_url();
     let query = uri.query().map(|q| format!("?{q}")).unwrap_or_default();
     let target_url = format!("{base_url}{effective_path}{query}");
+    let target_host = base_url
+        .strip_prefix("https://")
+        .or_else(|| base_url.strip_prefix("http://"))
+        .unwrap_or(base_url)
+        .split('/')
+        .next()
+        .unwrap_or("");
+    let request_category = super::classify::classify_request(target_host, effective_path);
+
+    // Reverse-proxy requests can still be telemetry (for example Codex posts
+    // analytics events to chatgpt.com/backend-api/codex/analytics-events/events).
+    // Enforce Pure/Lockdown here too, not just in CONNECT MITM.
+    if let Some(ref sid) = session_id
+        && state
+            .proxy_modes
+            .should_block(sid, &request_category.to_string())
+    {
+        info!(
+            request_id = %request_id,
+            target_url = %target_url,
+            session = %sid,
+            category = %request_category,
+            mode = ?state.proxy_modes.get(sid),
+            "reverse-proxy request blocked by proxy mode"
+        );
+
+        let log_entry = ApiRequestLog {
+            id: request_id,
+            session_id: session_id.clone(),
+            method: method.to_string(),
+            url: target_url.clone(),
+            status_code: 403,
+            latency_ms: start.elapsed().as_millis() as u64,
+            request_size: 0,
+            response_size: 0,
+            request_body: String::new(),
+            response_body: format!("Blocked by proxy mode ({:?})", state.proxy_modes.get(sid)),
+            request_headers: vec![],
+            response_headers: vec![],
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as i64,
+            category: Some(request_category.to_string()),
+        };
+        {
+            let mut cap = state.captured.write().await;
+            if cap.len() >= MAX_CAPTURED_REQUESTS {
+                cap.pop_front();
+            }
+            cap.push_back(log_entry.clone());
+        }
+        let _ = state.event_tx.send(log_entry);
+
+        return (StatusCode::FORBIDDEN, "Blocked by proxy mode").into_response();
+    }
 
     // ── WebSocket Upgrade Detection ────────────────────────────────────
     // Check BEFORE body.collect() — consuming the body prevents hyper upgrade.
@@ -342,6 +476,19 @@ pub async fn proxy_handler(
         })
         .collect();
 
+    let mut transform_bytes = if request_uses_zstd(&request_headers) {
+        match try_decompress_request(&request_bytes, &request_headers) {
+            Some(decoded) => Bytes::from(decoded),
+            None => {
+                warn!(request_id = %request_id, "failed to decompress zstd request body for transforms");
+                request_bytes.clone()
+            }
+        }
+    } else {
+        request_bytes.clone()
+    };
+    let mut request_body_modified = false;
+
     // ── Intercept Gate ──────────────────────────────────────────────────
     // If this session's intercept mode is Manual, hold the request and wait
     // for a user decision (Forward/Drop) via the API.
@@ -360,84 +507,6 @@ pub async fn proxy_handler(
         "intercept decision"
     );
 
-    if should_intercept {
-        let intercept_id = uuid::Uuid::new_v4().to_string();
-        let (decision_tx, decision_rx) = oneshot::channel();
-
-        let pending = PendingIntercept {
-            id: intercept_id.clone(),
-            session_id: session_id.clone(),
-            method: method.to_string(),
-            url: target_url.clone(),
-            provider,
-            request_body: request_bytes.to_vec(),
-            request_headers: request_headers.clone(),
-            timestamp: std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as i64,
-            decision_tx,
-        };
-
-        state
-            .pending_intercepts
-            .write()
-            .await
-            .insert(intercept_id.clone(), pending);
-
-        info!(
-            intercept_id = %intercept_id,
-            session = ?session_id,
-            method = %method,
-            url = %target_url,
-            "request intercepted, awaiting decision"
-        );
-
-        // Wait indefinitely for user decision (no timeout — user may need
-        // minutes to inspect/edit the request, like in Burp Suite).
-        // If the server shuts down, the sender is dropped and we auto-forward.
-        // If the CLI client disconnects, Tokio cancels this handler future,
-        // dropping decision_rx. The dead PendingIntercept is cleaned up when
-        // someone tries to forward/drop it via the API (sender.is_closed() check).
-        let decision = match decision_rx.await {
-            Ok(decision) => decision,
-            Err(_) => {
-                // Sender dropped (server shutting down or API cleanup) — forward automatically
-                warn!(intercept_id = %intercept_id, "intercept sender dropped, auto-forwarding");
-                InterceptDecision::Forward {
-                    modified_body: None,
-                    modified_headers: None,
-                }
-            }
-        };
-
-        // Remove from pending (may already be removed by timeout branch above)
-        state.pending_intercepts.write().await.remove(&intercept_id);
-
-        match decision {
-            InterceptDecision::Forward {
-                modified_body,
-                modified_headers,
-            } => {
-                if let Some(body) = modified_body {
-                    request_bytes = Bytes::from(body);
-                }
-                if let Some(hdrs) = modified_headers {
-                    request_headers = hdrs;
-                }
-                info!(intercept_id = %intercept_id, "intercepted request forwarded");
-            }
-            InterceptDecision::Drop => {
-                info!(intercept_id = %intercept_id, "intercepted request dropped");
-                return (
-                    StatusCode::from_u16(499).unwrap_or(StatusCode::BAD_REQUEST),
-                    "Request dropped by interceptor",
-                )
-                    .into_response();
-            }
-        }
-    }
-
     // ── Image Injection ────────────────────────────────────────────────
     // If the GUI user has queued images for this session, inject them into
     // the API request body. Supports multiple API formats:
@@ -455,8 +524,8 @@ pub async fn proxy_handler(
         let mut pending = state.pending_images.write().await;
         if let Some(images) = pending.remove(sid)
             && !images.is_empty()
-            && !request_bytes.is_empty()
-            && let Ok(mut body_json) = serde_json::from_slice::<serde_json::Value>(&request_bytes)
+            && !transform_bytes.is_empty()
+            && let Ok(mut body_json) = serde_json::from_slice::<serde_json::Value>(&transform_bytes)
         {
             let mut injected = false;
 
@@ -546,7 +615,8 @@ pub async fn proxy_handler(
                     provider = %provider.label(),
                     "injected pending images into API request"
                 );
-                request_bytes = Bytes::from(modified);
+                transform_bytes = Bytes::from(modified);
+                request_body_modified = true;
             }
         }
     } // skip_image_injection
@@ -557,8 +627,8 @@ pub async fn proxy_handler(
     let skip_system_injection = provider == ApiProvider::GoogleCodeAssist
         && !effective_path.contains("streamGenerateContent");
     if !skip_system_injection
-        && !request_bytes.is_empty()
-        && let Ok(mut body_json) = serde_json::from_slice::<serde_json::Value>(&request_bytes)
+        && !transform_bytes.is_empty()
+        && let Ok(mut body_json) = serde_json::from_slice::<serde_json::Value>(&transform_bytes)
     {
         let inject_config = if let Some(ref sid) = session_id {
             state.inject_store.get(sid)
@@ -576,64 +646,135 @@ pub async fn proxy_handler(
                 presets = ?inject_config.presets,
                 "injected system prompt into API request"
             );
-            request_bytes = Bytes::from(modified);
+            transform_bytes = Bytes::from(modified);
+            request_body_modified = true;
         }
     }
 
     // ── Request Body Rewrite ──────────────────────────────────────────
     // Apply per-session model override, temperature, max_tokens, pure mode.
-    if !request_bytes.is_empty() {
+    let skip_body_rewrite = provider == ApiProvider::GoogleCodeAssist
+        && !effective_path.contains("generateContent")
+        && !effective_path.contains("streamGenerateContent");
+    if !transform_bytes.is_empty() {
         let rewrite_config = if let Some(ref sid) = session_id {
             state.rewrite_store.get(sid)
         } else {
             super::rewrite::RewriteConfig::default()
         };
-        if rewrite_config.is_active()
-            && let Ok(mut body_json) = serde_json::from_slice::<serde_json::Value>(&request_bytes)
+        if !skip_body_rewrite
+            && rewrite_config.is_active()
+            && let Ok(mut body_json) = serde_json::from_slice::<serde_json::Value>(&transform_bytes)
             && super::rewrite::apply_rewrites(&mut body_json, provider, &rewrite_config)
             && let Ok(modified) = serde_json::to_vec(&body_json)
         {
-            request_bytes = Bytes::from(modified);
+            transform_bytes = Bytes::from(modified);
+            request_body_modified = true;
         }
     }
+
+    if request_body_modified {
+        request_bytes = match try_recompress_request(&transform_bytes, &request_headers) {
+            Some(reencoded) => Bytes::from(reencoded),
+            None => {
+                warn!(request_id = %request_id, "failed to recompress modified zstd request body");
+                return (StatusCode::BAD_GATEWAY, "Bad Gateway").into_response();
+            }
+        };
+    }
+
+    // ── Intercept Gate ──────────────────────────────────────────────────
+    // Hold the fully transformed request so the pending body reflects the
+    // real upstream payload after image injection, prompt injection, and rewrite.
+    if should_intercept {
+        let intercept_id = uuid::Uuid::new_v4().to_string();
+        let (decision_tx, decision_rx) = oneshot::channel();
+
+        let pending = PendingIntercept {
+            id: intercept_id.clone(),
+            session_id: session_id.clone(),
+            method: method.to_string(),
+            url: target_url.clone(),
+            provider,
+            request_body: request_bytes.to_vec(),
+            request_headers: request_headers.clone(),
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as i64,
+            decision_tx,
+        };
+
+        state
+            .pending_intercepts
+            .write()
+            .await
+            .insert(intercept_id.clone(), pending);
+
+        info!(
+            intercept_id = %intercept_id,
+            session = ?session_id,
+            method = %method,
+            url = %target_url,
+            "request intercepted, awaiting decision"
+        );
+
+        let decision = match decision_rx.await {
+            Ok(decision) => decision,
+            Err(_) => {
+                warn!(intercept_id = %intercept_id, "intercept sender dropped, auto-forwarding");
+                InterceptDecision::Forward {
+                    modified_body: None,
+                    modified_headers: None,
+                }
+            }
+        };
+
+        state.pending_intercepts.write().await.remove(&intercept_id);
+
+        match decision {
+            InterceptDecision::Forward {
+                modified_body,
+                modified_headers,
+            } => {
+                if let Some(hdrs) = modified_headers {
+                    request_headers = hdrs;
+                }
+                if let Some(body) = modified_body {
+                    request_bytes = match try_recompress_request(&body, &request_headers) {
+                        Some(reencoded) => Bytes::from(reencoded),
+                        None => {
+                            warn!(intercept_id = %intercept_id, "failed to recompress modified intercept body");
+                            return (StatusCode::BAD_GATEWAY, "Bad Gateway").into_response();
+                        }
+                    };
+                }
+                info!(intercept_id = %intercept_id, "intercepted request forwarded");
+            }
+            InterceptDecision::Drop => {
+                info!(intercept_id = %intercept_id, "intercepted request dropped");
+                return (
+                    StatusCode::from_u16(499).unwrap_or(StatusCode::BAD_REQUEST),
+                    "Request dropped by interceptor",
+                )
+                    .into_response();
+            }
+        }
+    }
+
+    // ── API Key Rotation ──────────────────────────────────────────────
+    // Apply the selected provider key to the mutable header set so the
+    // actual forwarded headers and the captured/logged headers stay aligned.
+    apply_rotated_api_key(&mut request_headers, provider, &state.key_store);
 
     // ── Build forwarding request ────────────────────────────────────────
 
     let mut req_builder = state.client.request(method.clone(), &target_url);
 
-    // Forward headers (skip hop-by-hop + accept-encoding + content-length).
-    // Stripping accept-encoding lets reqwest handle decompression automatically,
-    // giving us cleartext response bodies for logging in the Network Tab.
-    // Content-length is stripped so reqwest sets it from the actual body
-    // (which may differ from the original after interceptor body modifications).
-    for (name, value) in headers.iter() {
-        let name_str = name.as_str();
-        if name_str == "host"
-            || name_str == "connection"
-            || name_str == "transfer-encoding"
-            || name_str == "accept-encoding"
-            || name_str == "content-length"
-        {
-            continue;
-        }
-        req_builder = req_builder.header(name.clone(), value.clone());
-    }
-
-    // ── API Key Rotation ──────────────────────────────────────────────
-    // If KeyStore has active keys for this provider, replace the Authorization header.
-    if state.key_store.has_active_keys(provider.label())
-        && let Some((_key_id, plaintext_key)) = state.key_store.select_key(provider.label())
-    {
-        let auth_value = match provider {
-            ApiProvider::Anthropic => plaintext_key.to_string(),
-            _ => format!("Bearer {plaintext_key}"),
-        };
-        let header_name = match provider {
-            ApiProvider::Anthropic => "x-api-key",
-            _ => "authorization",
-        };
-        req_builder = req_builder.header(header_name, auth_value);
-    }
+    // Forward the current mutable header set. This preserves manual header edits
+    // made in the intercept UI and keeps content-encoding aligned with any
+    // re-encoded request body after inject/rewrite transforms.
+    req_builder = apply_forward_headers(req_builder, &request_headers);
 
     if !request_bytes.is_empty() {
         req_builder = req_builder.body(request_bytes.to_vec());
@@ -646,18 +787,7 @@ pub async fn proxy_handler(
             // Retry once on connection error
             warn!("upstream connection failed, retrying: {e}");
             let mut retry_builder = state.client.request(method.clone(), &target_url);
-            for (name, value) in headers.iter() {
-                let name_str = name.as_str();
-                if name_str == "host"
-                    || name_str == "connection"
-                    || name_str == "transfer-encoding"
-                    || name_str == "accept-encoding"
-                    || name_str == "content-length"
-                {
-                    continue;
-                }
-                retry_builder = retry_builder.header(name.clone(), value.clone());
-            }
+            retry_builder = apply_forward_headers(retry_builder, &request_headers);
             if !request_bytes.is_empty() {
                 retry_builder = retry_builder.body(request_bytes.to_vec());
             }
@@ -1893,16 +2023,22 @@ async fn handle_websocket_proxy(
     req: axum::extract::Request,
 ) -> Response {
     use axum::extract::ws::WebSocketUpgrade;
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 
     // Build the upstream WebSocket URL (wss:// for https://)
     let ws_url = target_url
         .replacen("https://", "wss://", 1)
         .replacen("http://", "ws://", 1);
 
-    // Forward relevant headers to upstream (auth, cookies, etc.)
-    let mut ws_request = tokio_tungstenite::tungstenite::http::Request::builder()
-        .uri(&ws_url)
-        .method("GET");
+    // Start from tungstenite's client request so it generates a valid
+    // WebSocket handshake (host, upgrade, version, random key).
+    let mut ws_request = match ws_url.as_str().into_client_request() {
+        Ok(request) => request,
+        Err(e) => {
+            warn!(error = %e, url = %ws_url, "failed to build upstream WS request");
+            return (StatusCode::BAD_GATEWAY, "Bad Gateway").into_response();
+        }
+    };
 
     // Copy important headers from the original request
     let original_headers = req.headers();
@@ -1915,29 +2051,12 @@ async fn handle_websocket_proxy(
             | "connection"
             | "sec-websocket-key"
             | "sec-websocket-version"
-            | "sec-websocket-extensions"
-            | "sec-websocket-protocol" => continue,
+            | "sec-websocket-extensions" => continue,
             _ => {
-                if let Ok(header_name) =
-                    tokio_tungstenite::tungstenite::http::HeaderName::from_bytes(name.as_ref())
-                    && let Ok(header_value) =
-                        tokio_tungstenite::tungstenite::http::HeaderValue::from_bytes(
-                            value.as_bytes(),
-                        )
-                {
-                    ws_request = ws_request.header(header_name, header_value);
-                }
+                ws_request.headers_mut().append(name.clone(), value.clone());
             }
         }
     }
-
-    let ws_request = match ws_request.body(()) {
-        Ok(r) => r,
-        Err(e) => {
-            warn!(error = %e, "failed to build upstream WS request");
-            return (StatusCode::BAD_GATEWAY, "Bad Gateway").into_response();
-        }
-    };
 
     // Connect to upstream WebSocket
     let (upstream_ws, _upstream_response) = match tokio_tungstenite::connect_async(ws_request).await
@@ -2120,6 +2239,48 @@ mod tests {
             detect_provider(&headers, "/v1beta/models/gemini-pro"),
             ApiProvider::Google
         );
+    }
+
+    #[test]
+    fn rotated_api_key_uses_expected_header_names() {
+        let store = super::super::keys::KeyStore::new();
+        store.add_key("anthropic", "sk-ant-test-1", "Anthropic");
+        store.add_key("openai", "sk-proj-test-1", "OpenAI"); // gitleaks:allow
+        store.add_key(
+            "google-codeassist",
+            "AIzaSyB1234567890abcdefghijklmnopqrst", // gitleaks:allow
+            "Google",
+        );
+
+        let mut anthropic_headers = vec![("authorization".to_string(), "Bearer stale".to_string())];
+        apply_rotated_api_key(&mut anthropic_headers, ApiProvider::Anthropic, &store);
+        assert!(anthropic_headers
+            .iter()
+            .any(|(name, value)| name == "x-api-key" && value == "sk-ant-test-1"));
+        assert!(!anthropic_headers
+            .iter()
+            .any(|(name, _)| name == "authorization"));
+
+        let mut openai_headers = vec![("authorization".to_string(), "Bearer stale".to_string())];
+        apply_rotated_api_key(&mut openai_headers, ApiProvider::OpenAI, &store);
+        assert!(openai_headers
+            .iter()
+            .any(|(name, value)| name == "authorization" && value == "Bearer sk-proj-test-1"));
+
+        let mut google_headers = vec![
+            (
+                "x-goog-api-key".to_string(),
+                "AIzaSy-stale-1234567890abcdefghijklmnopqrst".to_string(),
+            ),
+            ("authorization".to_string(), "Bearer stale".to_string()),
+        ];
+        apply_rotated_api_key(&mut google_headers, ApiProvider::GoogleCodeAssist, &store);
+        assert!(google_headers.iter().any(|(name, value)| {
+            name == "x-goog-api-key" && value == "AIzaSyB1234567890abcdefghijklmnopqrst"
+        }));
+        assert!(!google_headers
+            .iter()
+            .any(|(name, _)| name == "authorization"));
     }
 
     #[tokio::test]

--- a/server/src/proxy/handler.rs
+++ b/server/src/proxy/handler.rs
@@ -1251,6 +1251,49 @@ pub async fn connect_handler(
     // Classify traffic
     let category = super::classify::classify_domain(&hostname);
 
+    // Check proxy mode (Lockdown blocks non-API, Pure blocks telemetry)
+    if let Some(ref sid) = session_id {
+        if state.proxy_modes.should_block(sid, &category.to_string()) {
+            info!(
+                target = %target_addr,
+                session = %sid,
+                category = %category,
+                mode = ?state.proxy_modes.get(sid),
+                "CONNECT blocked by proxy mode"
+            );
+
+            let log_entry = ApiRequestLog {
+                id: request_id,
+                session_id: session_id.clone(),
+                method: "CONNECT".to_string(),
+                url: format!("tunnel://{target_addr}"),
+                status_code: 403,
+                latency_ms: start.elapsed().as_millis() as u64,
+                request_size: 0,
+                response_size: 0,
+                request_body: String::new(),
+                response_body: format!("Blocked by proxy mode ({:?})", state.proxy_modes.get(sid)),
+                request_headers: vec![],
+                response_headers: vec![],
+                timestamp: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as i64,
+                category: Some(category.to_string()),
+            };
+            {
+                let mut cap = state.captured.write().await;
+                if cap.len() >= MAX_CAPTURED_REQUESTS {
+                    cap.pop_front();
+                }
+                cap.push_back(log_entry.clone());
+            }
+            let _ = state.event_tx.send(log_entry);
+
+            return (StatusCode::FORBIDDEN, "Blocked by proxy mode").into_response();
+        }
+    }
+
     // Check network rules (block before even connecting)
     let rule_action = state
         .network_rules

--- a/server/src/proxy/handler.rs
+++ b/server/src/proxy/handler.rs
@@ -161,11 +161,10 @@ fn apply_rotated_api_key(
     };
 
     headers.retain(|(name, _)| {
-        !name.eq_ignore_ascii_case(header_name)
-            && !(provider == ApiProvider::Anthropic && name.eq_ignore_ascii_case("authorization"))
-            && !(matches!(
+        !(name.eq_ignore_ascii_case(header_name)
+            || matches!(
                 provider,
-                ApiProvider::Google | ApiProvider::GoogleCodeAssist
+                ApiProvider::Anthropic | ApiProvider::Google | ApiProvider::GoogleCodeAssist
             ) && name.eq_ignore_ascii_case("authorization"))
     });
     headers.push((header_name.to_string(), header_value));
@@ -1382,46 +1381,46 @@ pub async fn connect_handler(
     let category = super::classify::classify_domain(&hostname);
 
     // Check proxy mode (Lockdown blocks non-API, Pure blocks telemetry)
-    if let Some(ref sid) = session_id {
-        if state.proxy_modes.should_block(sid, &category.to_string()) {
-            info!(
-                target = %target_addr,
-                session = %sid,
-                category = %category,
-                mode = ?state.proxy_modes.get(sid),
-                "CONNECT blocked by proxy mode"
-            );
+    if let Some(ref sid) = session_id
+        && state.proxy_modes.should_block(sid, &category.to_string())
+    {
+        info!(
+            target = %target_addr,
+            session = %sid,
+            category = %category,
+            mode = ?state.proxy_modes.get(sid),
+            "CONNECT blocked by proxy mode"
+        );
 
-            let log_entry = ApiRequestLog {
-                id: request_id,
-                session_id: session_id.clone(),
-                method: "CONNECT".to_string(),
-                url: format!("tunnel://{target_addr}"),
-                status_code: 403,
-                latency_ms: start.elapsed().as_millis() as u64,
-                request_size: 0,
-                response_size: 0,
-                request_body: String::new(),
-                response_body: format!("Blocked by proxy mode ({:?})", state.proxy_modes.get(sid)),
-                request_headers: vec![],
-                response_headers: vec![],
-                timestamp: std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_millis() as i64,
-                category: Some(category.to_string()),
-            };
-            {
-                let mut cap = state.captured.write().await;
-                if cap.len() >= MAX_CAPTURED_REQUESTS {
-                    cap.pop_front();
-                }
-                cap.push_back(log_entry.clone());
+        let log_entry = ApiRequestLog {
+            id: request_id,
+            session_id: session_id.clone(),
+            method: "CONNECT".to_string(),
+            url: format!("tunnel://{target_addr}"),
+            status_code: 403,
+            latency_ms: start.elapsed().as_millis() as u64,
+            request_size: 0,
+            response_size: 0,
+            request_body: String::new(),
+            response_body: format!("Blocked by proxy mode ({:?})", state.proxy_modes.get(sid)),
+            request_headers: vec![],
+            response_headers: vec![],
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as i64,
+            category: Some(category.to_string()),
+        };
+        {
+            let mut cap = state.captured.write().await;
+            if cap.len() >= MAX_CAPTURED_REQUESTS {
+                cap.pop_front();
             }
-            let _ = state.event_tx.send(log_entry);
-
-            return (StatusCode::FORBIDDEN, "Blocked by proxy mode").into_response();
+            cap.push_back(log_entry.clone());
         }
+        let _ = state.event_tx.send(log_entry);
+
+        return (StatusCode::FORBIDDEN, "Blocked by proxy mode").into_response();
     }
 
     // Check network rules (block before even connecting)

--- a/server/src/proxy/inject.rs
+++ b/server/src/proxy/inject.rs
@@ -145,41 +145,63 @@ pub fn inject_into_body(
             }
             true
         }
-        ApiProvider::GoogleCodeAssist | ApiProvider::Google => {
-            // Try existing system_instruction.parts or request.system_instruction.parts
-            let targets = [
-                vec!["system_instruction", "parts"],
-                vec!["request", "system_instruction", "parts"],
-            ];
-            for target in &targets {
-                let mut cursor = &mut *body;
-                let mut found = true;
-                for (i, key) in target.iter().enumerate() {
-                    if i == target.len() - 1 {
-                        if let Some(arr) = cursor.get_mut(*key).and_then(|v| v.as_array_mut()) {
-                            arr.push(serde_json::json!({"text": text}));
-                            return true;
-                        }
-                        found = false;
-                    } else if cursor.get(*key).is_some() {
-                        cursor = &mut cursor[*key];
-                    } else {
-                        found = false;
-                        break;
-                    }
-                }
-                if found {
+        ApiProvider::Google => {
+            // Google APIs commonly expose camelCase JSON names, but keep reading
+            // existing snake_case variants for backward compatibility.
+            for target in [
+                &["systemInstruction", "parts"][..],
+                &["system_instruction", "parts"][..],
+                &["request", "systemInstruction", "parts"][..],
+                &["request", "system_instruction", "parts"][..],
+            ] {
+                if append_text_part(body, target, text) {
                     return true;
                 }
             }
-            // Create system_instruction if none exists
-            body["system_instruction"] = serde_json::json!({
+
+            body["systemInstruction"] = serde_json::json!({
+                "parts": [{"text": text}]
+            });
+            true
+        }
+        ApiProvider::GoogleCodeAssist => {
+            // Gemini Code Assist uses nested request.systemInstruction with
+            // camelCase field names. Top-level snake_case breaks the request
+            // with INVALID_ARGUMENT on cloudcode-pa.googleapis.com.
+            for target in [
+                &["request", "systemInstruction", "parts"][..],
+                &["request", "system_instruction", "parts"][..],
+                &["systemInstruction", "parts"][..],
+                &["system_instruction", "parts"][..],
+            ] {
+                if append_text_part(body, target, text) {
+                    return true;
+                }
+            }
+
+            if !body.get("request").is_some_and(|value| value.is_object()) {
+                body["request"] = serde_json::json!({});
+            }
+            body["request"]["systemInstruction"] = serde_json::json!({
+                "role": "user",
                 "parts": [{"text": text}]
             });
             true
         }
         ApiProvider::OpenAI | ApiProvider::ChatGPT => {
-            // Prepend system message to messages array (or input array for Codex)
+            // Codex/Responses API keeps the system prompt in a top-level
+            // "instructions" string instead of a messages/input system block.
+            if let Some(instructions) = body.get_mut("instructions").and_then(|v| v.as_str()) {
+                let merged = if instructions.is_empty() {
+                    text.to_string()
+                } else {
+                    format!("{instructions}\n\n{text}")
+                };
+                body["instructions"] = serde_json::Value::String(merged);
+                return true;
+            }
+
+            // Otherwise prepend a system message to messages/input.
             let msg_key = if body.get("input").is_some() {
                 "input"
             } else {
@@ -199,6 +221,26 @@ pub fn inject_into_body(
             }
         }
     }
+}
+
+fn append_text_part(body: &mut serde_json::Value, path: &[&str], text: &str) -> bool {
+    let mut cursor = body;
+    for (index, key) in path.iter().enumerate() {
+        if index == path.len() - 1 {
+            if let Some(parts) = cursor.get_mut(*key).and_then(|value| value.as_array_mut()) {
+                parts.push(serde_json::json!({ "text": text }));
+                return true;
+            }
+            return false;
+        }
+
+        let Some(next) = cursor.get_mut(*key) else {
+            return false;
+        };
+        cursor = next;
+    }
+
+    false
 }
 
 /// Per-session inject config storage.
@@ -330,7 +372,50 @@ mod tests {
             "new instruction",
         );
         assert!(result);
-        assert!(body["system_instruction"]["parts"].is_array());
+        assert!(body["systemInstruction"]["parts"].is_array());
+    }
+
+    #[test]
+    fn inject_google_codeassist_creates_nested_system_instruction() {
+        let mut body = serde_json::json!({
+            "model": "gemini-2.5-flash-lite",
+            "request": {
+                "contents": []
+            }
+        });
+        let result = inject_into_body(
+            &mut body,
+            super::super::handler::ApiProvider::GoogleCodeAssist,
+            "new instruction",
+        );
+        assert!(result);
+        assert_eq!(body["request"]["systemInstruction"]["role"], "user");
+        assert!(body["request"]["systemInstruction"]["parts"].is_array());
+        assert!(body.get("system_instruction").is_none());
+    }
+
+    #[test]
+    fn inject_google_codeassist_appends_existing_nested_system_instruction() {
+        let mut body = serde_json::json!({
+            "request": {
+                "systemInstruction": {
+                    "role": "user",
+                    "parts": [{"text": "existing"}]
+                },
+                "contents": []
+            }
+        });
+        let result = inject_into_body(
+            &mut body,
+            super::super::handler::ApiProvider::GoogleCodeAssist,
+            "injected",
+        );
+        assert!(result);
+        let parts = body["request"]["systemInstruction"]["parts"]
+            .as_array()
+            .unwrap();
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[1]["text"], "injected");
     }
 
     #[test]
@@ -354,6 +439,27 @@ mod tests {
                 .unwrap()
                 .contains("system text")
         );
+    }
+
+    #[test]
+    fn inject_chatgpt_appends_instructions_string() {
+        let mut body = serde_json::json!({
+            "type": "response.create",
+            "model": "gpt-5.4",
+            "instructions": "existing instructions",
+            "input": [{"role": "user", "content": "hello"}]
+        });
+        let result = inject_into_body(
+            &mut body,
+            super::super::handler::ApiProvider::ChatGPT,
+            "system text",
+        );
+        assert!(result);
+        let instructions = body["instructions"].as_str().unwrap();
+        assert!(instructions.contains("existing instructions"));
+        assert!(instructions.contains("system text"));
+        let input = body["input"].as_array().unwrap();
+        assert_eq!(input.len(), 1, "instructions path should not prepend input");
     }
 
     #[test]

--- a/server/src/proxy/keys.rs
+++ b/server/src/proxy/keys.rs
@@ -7,8 +7,8 @@ use dashmap::DashMap;
 use ring::aead;
 use ring::rand::{SecureRandom, SystemRandom};
 use serde::{Deserialize, Serialize};
-use std::sync::atomic::{AtomicU64, Ordering};
-use tracing::warn;
+use std::path::{Path, PathBuf};
+use tracing::{info, warn};
 
 /// An API key entry in the key store.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -42,6 +42,65 @@ fn derive_key() -> aead::LessSafeKey {
     let unbound_key =
         aead::UnboundKey::new(&aead::AES_256_GCM, &key_bytes).expect("AES key creation failed");
     aead::LessSafeKey::new(unbound_key)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct PersistedKeyStore {
+    keys: Vec<ApiKeyEntry>,
+}
+
+fn key_store_path() -> PathBuf {
+    std::env::var("NOAIDE_API_KEYS_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/data/noaide/api-keys.json"))
+}
+
+fn save_to_path(store: &KeyStore, path: &Path) -> Result<(), std::io::Error> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let mut keys = store.list_keys();
+    keys.sort_by(|left, right| left.id.cmp(&right.id));
+    let payload = PersistedKeyStore { keys };
+    let json = serde_json::to_string_pretty(&payload)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    std::fs::write(path, json)?;
+    debug_assert!(path.is_absolute());
+    Ok(())
+}
+
+fn load_from_path(store: &KeyStore, path: &Path) -> Result<usize, std::io::Error> {
+    let json = match std::fs::read_to_string(path) {
+        Ok(json) => json,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => return Err(e),
+    };
+
+    let payload: PersistedKeyStore = serde_json::from_str(&json)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    for entry in &payload.keys {
+        store.keys.insert(entry.id.clone(), entry.clone());
+    }
+
+    Ok(payload.keys.len())
+}
+
+pub fn save_to_disk(store: &KeyStore) -> Result<(), std::io::Error> {
+    let path = key_store_path();
+    save_to_path(store, &path)?;
+    info!(path = %path.display(), count = store.keys.len(), "persisted api keys to disk");
+    Ok(())
+}
+
+pub fn load_from_disk(store: &KeyStore) -> Result<usize, std::io::Error> {
+    let path = key_store_path();
+    let loaded = load_from_path(store, &path)?;
+    if loaded > 0 {
+        info!(path = %path.display(), loaded = loaded, "restored api keys from disk");
+    }
+    Ok(loaded)
 }
 
 /// Encrypt an API key string.
@@ -90,15 +149,15 @@ pub fn decrypt_key(encrypted: &str) -> Result<String, String> {
 /// Key store with round-robin selection and rate-limit tracking.
 pub struct KeyStore {
     keys: DashMap<String, ApiKeyEntry>,
-    /// Round-robin counter
-    counter: AtomicU64,
+    /// Round-robin counters keyed by provider label.
+    provider_counters: DashMap<String, u64>,
 }
 
 impl KeyStore {
     pub fn new() -> Self {
         Self {
             keys: DashMap::new(),
-            counter: AtomicU64::new(0),
+            provider_counters: DashMap::new(),
         }
     }
 
@@ -126,6 +185,16 @@ impl KeyStore {
         self.keys.remove(id).is_some()
     }
 
+    /// Explicitly set whether a key is active.
+    pub fn set_active(&self, id: &str, active: bool) -> bool {
+        if let Some(mut entry) = self.keys.get_mut(id) {
+            entry.active = active;
+            true
+        } else {
+            false
+        }
+    }
+
     /// Get all keys (without decrypted values).
     pub fn list_keys(&self) -> Vec<ApiKeyEntry> {
         self.keys.iter().map(|r| r.value().clone()).collect()
@@ -134,7 +203,7 @@ impl KeyStore {
     /// Select the next active key for a provider using round-robin.
     /// Returns (key_id, decrypted_key) or None if no active keys.
     pub fn select_key(&self, provider: &str) -> Option<(String, String)> {
-        let active: Vec<_> = self
+        let mut active: Vec<_> = self
             .keys
             .iter()
             .filter(|r| r.value().provider == provider && r.value().active)
@@ -145,7 +214,19 @@ impl KeyStore {
             return None;
         }
 
-        let idx = self.counter.fetch_add(1, Ordering::Relaxed) as usize % active.len();
+        // DashMap iteration order is not stable. Sort so round-robin selection
+        // stays deterministic across calls and providers.
+        active.sort_by(|left, right| left.0.cmp(&right.0));
+
+        let idx = {
+            let mut counter = self
+                .provider_counters
+                .entry(provider.to_string())
+                .or_insert(0);
+            let idx = (*counter as usize) % active.len();
+            *counter += 1;
+            idx
+        };
         let (id, encrypted) = &active[idx];
 
         match decrypt_key(encrypted) {
@@ -236,6 +317,36 @@ impl Default for KeyStore {
 mod tests {
     use super::*;
 
+    fn temp_keys_path() -> PathBuf {
+        let id = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("noaide-api-keys-{id}.json"))
+    }
+
+    #[test]
+    fn persist_roundtrip_uses_encrypted_values() {
+        let path = temp_keys_path();
+        let store = KeyStore::new();
+        store.add_key(
+            "anthropic",
+            "sk-ant-persist-roundtrip-1234567890",
+            "Persist Roundtrip",
+        );
+
+        save_to_path(&store, &path).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(!content.contains("sk-ant-persist-roundtrip-1234567890"));
+
+        let loaded = KeyStore::new();
+        assert_eq!(load_from_path(&loaded, &path).unwrap(), 1);
+        let (_, plaintext) = loaded.select_key("anthropic").unwrap();
+        assert_eq!(plaintext, "sk-ant-persist-roundtrip-1234567890");
+
+        let _ = std::fs::remove_file(path);
+    }
+
     #[test]
     fn encrypt_decrypt_roundtrip() {
         let key = "sk-ant-api03-test-key-1234567890";
@@ -259,19 +370,19 @@ mod tests {
     }
 
     #[test]
-    fn round_robin_distribution() {
+    fn round_robin_distribution_is_balanced() {
         let store = KeyStore::new();
         store.add_key("anthropic", "key-1", "Key 1");
         store.add_key("anthropic", "key-2", "Key 2");
 
-        let mut keys_used = std::collections::HashSet::new();
-        for _ in 0..10 {
+        let mut counts = std::collections::HashMap::new();
+        for _ in 0..4 {
             if let Some((_, key)) = store.select_key("anthropic") {
-                keys_used.insert(key);
+                *counts.entry(key).or_insert(0usize) += 1;
             }
         }
-        // Both keys should have been used
-        assert_eq!(keys_used.len(), 2);
+        assert_eq!(counts.get("key-1"), Some(&2));
+        assert_eq!(counts.get("key-2"), Some(&2));
     }
 
     #[test]
@@ -314,5 +425,29 @@ mod tests {
 
         let (_, key) = store.select_key("openai").unwrap();
         assert_eq!(key, "key-oai");
+    }
+
+    #[test]
+    fn round_robin_is_independent_per_provider() {
+        let store = KeyStore::new();
+        store.add_key("anthropic", "ant-a", "Ant A");
+        store.add_key("anthropic", "ant-b", "Ant B");
+        store.add_key("openai", "oai-a", "OAI A");
+        store.add_key("openai", "oai-b", "OAI B");
+
+        let mut ant_counts = std::collections::HashMap::new();
+        let mut oai_counts = std::collections::HashMap::new();
+
+        for _ in 0..4 {
+            let (_, ant_key) = store.select_key("anthropic").unwrap();
+            *ant_counts.entry(ant_key).or_insert(0usize) += 1;
+            let (_, oai_key) = store.select_key("openai").unwrap();
+            *oai_counts.entry(oai_key).or_insert(0usize) += 1;
+        }
+
+        assert_eq!(ant_counts.get("ant-a"), Some(&2));
+        assert_eq!(ant_counts.get("ant-b"), Some(&2));
+        assert_eq!(oai_counts.get("oai-a"), Some(&2));
+        assert_eq!(oai_counts.get("oai-b"), Some(&2));
     }
 }

--- a/server/src/proxy/mitm.rs
+++ b/server/src/proxy/mitm.rs
@@ -90,18 +90,7 @@ pub fn build_log(
             .as_millis() as i64,
         request_size: request_body.len(),
         response_size: response_body.len(),
-        category: {
-            // Classify reverse-proxy requests by extracting host from URL
-            let host = url
-                .strip_prefix("https://")
-                .or_else(|| url.strip_prefix("http://"))
-                .unwrap_or(url)
-                .split('/')
-                .next()
-                .unwrap_or("");
-            let cat = super::classify::classify_domain(host);
-            Some(cat.to_string())
-        },
+        category: Some(super::classify::classify_url(url).to_string()),
     }
 }
 
@@ -182,5 +171,23 @@ mod tests {
             elapsed.as_millis() < 500,
             "redaction overhead too high: {elapsed:?}"
         );
+    }
+
+    #[test]
+    fn build_log_classifies_codex_analytics_as_telemetry() {
+        let log = build_log(
+            "req-1".to_string(),
+            None,
+            "POST",
+            "https://chatgpt.com/backend-api/codex/analytics-events/events",
+            b"{}",
+            &[],
+            b"{}",
+            &[],
+            200,
+            std::time::Instant::now(),
+        );
+
+        assert_eq!(log.category.as_deref(), Some("telemetry"));
     }
 }

--- a/server/src/proxy/modes.rs
+++ b/server/src/proxy/modes.rs
@@ -54,9 +54,10 @@ impl ProxyModeStore {
     /// Check if a request should be blocked based on the current mode and category.
     pub fn should_block(&self, session_id: &str, category: &str) -> bool {
         let mode = self.get(session_id);
+        let normalized = category.to_ascii_lowercase();
         match mode {
-            ProxyMode::Lockdown => category != "Api",
-            ProxyMode::Pure => category == "Telemetry",
+            ProxyMode::Lockdown => normalized != "api",
+            ProxyMode::Pure => normalized == "telemetry",
             _ => false,
         }
     }
@@ -94,28 +95,38 @@ mod tests {
     fn lockdown_blocks_non_api() {
         let store = ProxyModeStore::new();
         store.set("s1".to_string(), ProxyMode::Lockdown);
-        assert!(store.should_block("s1", "Telemetry"));
-        assert!(store.should_block("s1", "Update"));
-        assert!(store.should_block("s1", "Auth"));
-        assert!(!store.should_block("s1", "Api"));
+        assert!(store.should_block("s1", "telemetry"));
+        assert!(store.should_block("s1", "update"));
+        assert!(store.should_block("s1", "auth"));
+        assert!(!store.should_block("s1", "api"));
     }
 
     #[test]
     fn pure_blocks_telemetry_only() {
         let store = ProxyModeStore::new();
         store.set("s1".to_string(), ProxyMode::Pure);
-        assert!(store.should_block("s1", "Telemetry"));
-        assert!(!store.should_block("s1", "Api"));
-        assert!(!store.should_block("s1", "Auth"));
-        assert!(!store.should_block("s1", "Update"));
+        assert!(store.should_block("s1", "telemetry"));
+        assert!(!store.should_block("s1", "api"));
+        assert!(!store.should_block("s1", "auth"));
+        assert!(!store.should_block("s1", "update"));
     }
 
     #[test]
     fn auto_blocks_nothing() {
         let store = ProxyModeStore::new();
         store.set("s1".to_string(), ProxyMode::Auto);
-        assert!(!store.should_block("s1", "Telemetry"));
+        assert!(!store.should_block("s1", "telemetry"));
+        assert!(!store.should_block("s1", "api"));
+    }
+
+    #[test]
+    fn category_check_is_case_insensitive() {
+        let store = ProxyModeStore::new();
+        store.set("s1".to_string(), ProxyMode::Lockdown);
         assert!(!store.should_block("s1", "Api"));
+
+        store.set("s2".to_string(), ProxyMode::Pure);
+        assert!(store.should_block("s2", "Telemetry"));
     }
 
     #[test]

--- a/server/src/proxy/persist.rs
+++ b/server/src/proxy/persist.rs
@@ -13,6 +13,8 @@ pub struct ProxyConfig {
     pub mode: super::modes::ProxyMode,
     pub inject: super::inject::InjectConfig,
     pub rewrite: super::rewrite::RewriteConfig,
+    #[serde(default)]
+    pub rules: Vec<super::rules::NetworkRule>,
 }
 
 /// Config directory for proxy persistence.
@@ -135,6 +137,33 @@ pub fn startup_cleanup() {
     }
 }
 
+/// Load all persisted configs into the proxy state stores.
+/// Call at server startup after cleanup.
+pub fn load_all_into_stores(
+    modes: &super::modes::ProxyModeStore,
+    inject: &super::inject::InjectStore,
+    rewrite: &super::rewrite::RewriteStore,
+    rules: &super::rules::NetworkRulesEngine,
+) -> usize {
+    let sessions = list_saved_sessions();
+    let mut loaded = 0;
+    for sid in &sessions {
+        if let Some(config) = load_config(sid) {
+            modes.set(sid.clone(), config.mode);
+            inject.set(sid.clone(), config.inject);
+            rewrite.set(sid.clone(), config.rewrite);
+            if !config.rules.is_empty() {
+                rules.set_rules(sid, config.rules);
+            }
+            loaded += 1;
+        }
+    }
+    if loaded > 0 {
+        info!(loaded = loaded, total = sessions.len(), "restored proxy configs from disk");
+    }
+    loaded
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -166,6 +195,7 @@ mod tests {
                 model_override: Some("claude-sonnet-4-6".to_string()),
                 ..Default::default()
             },
+            rules: vec![],
         };
 
         let json = serde_json::to_string_pretty(&config).unwrap();

--- a/server/src/proxy/persist.rs
+++ b/server/src/proxy/persist.rs
@@ -139,17 +139,24 @@ pub fn startup_cleanup() {
 
 /// Load all persisted configs into the proxy state stores.
 /// Call at server startup after cleanup.
-pub fn load_all_into_stores(
+pub async fn load_all_into_stores(
     modes: &super::modes::ProxyModeStore,
     inject: &super::inject::InjectStore,
     rewrite: &super::rewrite::RewriteStore,
     rules: &super::rules::NetworkRulesEngine,
+    intercept_modes: &tokio::sync::RwLock<
+        std::collections::HashMap<String, super::handler::InterceptMode>,
+    >,
 ) -> usize {
     let sessions = list_saved_sessions();
     let mut loaded = 0;
+    let mut intercept_modes_guard = intercept_modes.write().await;
     for sid in &sessions {
         if let Some(config) = load_config(sid) {
             modes.set(sid.clone(), config.mode);
+            if config.mode == super::modes::ProxyMode::Manual {
+                intercept_modes_guard.insert(sid.clone(), super::handler::InterceptMode::Manual);
+            }
             inject.set(sid.clone(), config.inject);
             rewrite.set(sid.clone(), config.rewrite);
             if !config.rules.is_empty() {
@@ -159,7 +166,11 @@ pub fn load_all_into_stores(
         }
     }
     if loaded > 0 {
-        info!(loaded = loaded, total = sessions.len(), "restored proxy configs from disk");
+        info!(
+            loaded = loaded,
+            total = sessions.len(),
+            "restored proxy configs from disk"
+        );
     }
     loaded
 }

--- a/server/src/proxy/rewrite.rs
+++ b/server/src/proxy/rewrite.rs
@@ -179,7 +179,9 @@ fn strip_to_essentials(body: &mut serde_json::Value, provider: super::handler::A
 
     match provider {
         ApiProvider::Anthropic => {
-            obj.retain(|key, _| ["model", "messages", "stream", "max_tokens"].contains(&key.as_str()));
+            obj.retain(|key, _| {
+                ["model", "messages", "stream", "max_tokens"].contains(&key.as_str())
+            });
         }
         ApiProvider::OpenAI => {
             obj.retain(|key, _| {
@@ -191,7 +193,9 @@ fn strip_to_essentials(body: &mut serde_json::Value, provider: super::handler::A
             obj.retain(|key, _| ["model", "input"].contains(&key.as_str()));
         }
         ApiProvider::Google => {
-            obj.retain(|key, _| ["model", "contents", "stream", "generationConfig"].contains(&key.as_str()));
+            obj.retain(|key, _| {
+                ["model", "contents", "stream", "generationConfig"].contains(&key.as_str())
+            });
         }
         ApiProvider::GoogleCodeAssist => {
             let model = obj.remove("model");
@@ -229,11 +233,10 @@ fn strip_system_prompt(
     use super::handler::ApiProvider;
 
     match provider {
-        ApiProvider::Anthropic => {
-            body.as_object_mut()
-                .map(|obj| obj.remove("system").is_some())
-                .unwrap_or(false)
-        }
+        ApiProvider::Anthropic => body
+            .as_object_mut()
+            .map(|obj| obj.remove("system").is_some())
+            .unwrap_or(false),
         ApiProvider::OpenAI | ApiProvider::ChatGPT => {
             let Some(obj) = body.as_object_mut() else {
                 return false;
@@ -505,9 +508,11 @@ mod tests {
         let modified = apply_rewrites(&mut body, ApiProvider::GoogleCodeAssist, &config);
         assert!(modified);
         assert_eq!(body["model"], "gemini-2.5-pro");
-        assert!(body["request"]["generationConfig"]
-            .get("thinkingConfig")
-            .is_none());
+        assert!(
+            body["request"]["generationConfig"]
+                .get("thinkingConfig")
+                .is_none()
+        );
         assert_eq!(body["request"]["generationConfig"]["temperature"], 1);
     }
 

--- a/server/src/proxy/rewrite.rs
+++ b/server/src/proxy/rewrite.rs
@@ -2,14 +2,16 @@
 //!
 //! Apply per-session rewrites to API request bodies before forwarding to upstream.
 //! Supports model override, temperature, max tokens, thinking type, and pure mode
-//! (strip everything except model + messages + stream).
+//! (strip provider-specific requests to their essential fields).
 
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
+use serde_json::Map;
 use tracing::debug;
 
 /// Per-session rewrite configuration.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
 pub struct RewriteConfig {
     /// Override the model name in the request
     pub model_override: Option<String>,
@@ -19,8 +21,12 @@ pub struct RewriteConfig {
     pub max_tokens: Option<u64>,
     /// Override thinking type (for Anthropic extended thinking)
     pub thinking_type: Option<String>,
-    /// Pure mode: strip everything except model + messages + stream
+    /// Pure mode: strip provider-specific request bodies to essentials
     pub pure_mode: bool,
+    /// Remove top-level system prompt fields / system messages
+    pub strip_system_prompt: bool,
+    /// Remove tool declarations and tool-choice hints
+    pub strip_tools: bool,
 }
 
 impl RewriteConfig {
@@ -30,6 +36,8 @@ impl RewriteConfig {
             || self.max_tokens.is_some()
             || self.thinking_type.is_some()
             || self.pure_mode
+            || self.strip_system_prompt
+            || self.strip_tools
     }
 }
 
@@ -47,12 +55,24 @@ pub fn apply_rewrites(
         return false;
     }
 
+    if provider == ApiProvider::GoogleCodeAssist && !is_code_assist_conversation_body(body) {
+        return false;
+    }
+
     let mut modified = false;
 
     // Pure mode: strip to essentials first
     if config.pure_mode {
         strip_to_essentials(body, provider);
         modified = true;
+    }
+
+    if config.strip_system_prompt {
+        modified |= strip_system_prompt(body, provider);
+    }
+
+    if config.strip_tools {
+        modified |= strip_tools(body, provider);
     }
 
     // Model override
@@ -64,6 +84,9 @@ pub fn apply_rewrites(
             }
             ApiProvider::Google | ApiProvider::GoogleCodeAssist => {
                 body["model"] = serde_json::Value::String(model.clone());
+                if !google_model_supports_thinking(model) {
+                    strip_google_thinking_config(body, provider);
+                }
                 modified = true;
             }
         }
@@ -76,12 +99,18 @@ pub fn apply_rewrites(
                 body["temperature"] = serde_json::json!(temp);
                 modified = true;
             }
-            ApiProvider::Google | ApiProvider::GoogleCodeAssist => {
+            ApiProvider::Google => {
                 if body.get("generationConfig").is_none() {
                     body["generationConfig"] = serde_json::json!({});
                 }
                 body["generationConfig"]["temperature"] = serde_json::json!(temp);
                 modified = true;
+            }
+            ApiProvider::GoogleCodeAssist => {
+                if let Some(config) = ensure_object_path(body, &["request", "generationConfig"]) {
+                    config.insert("temperature".to_string(), serde_json::json!(temp));
+                    modified = true;
+                }
             }
         }
     }
@@ -97,12 +126,18 @@ pub fn apply_rewrites(
                 body["max_output_tokens"] = serde_json::json!(max);
                 modified = true;
             }
-            ApiProvider::Google | ApiProvider::GoogleCodeAssist => {
+            ApiProvider::Google => {
                 if body.get("generationConfig").is_none() {
                     body["generationConfig"] = serde_json::json!({});
                 }
                 body["generationConfig"]["maxOutputTokens"] = serde_json::json!(max);
                 modified = true;
+            }
+            ApiProvider::GoogleCodeAssist => {
+                if let Some(config) = ensure_object_path(body, &["request", "generationConfig"]) {
+                    config.insert("maxOutputTokens".to_string(), serde_json::json!(max));
+                    modified = true;
+                }
             }
         }
     }
@@ -111,11 +146,17 @@ pub fn apply_rewrites(
     if let Some(ref thinking) = config.thinking_type
         && provider == ApiProvider::Anthropic
     {
-        if body.get("thinking").is_none() {
-            body["thinking"] = serde_json::json!({});
+        if thinking == "remove" {
+            if let Some(obj) = body.as_object_mut() {
+                modified |= obj.remove("thinking").is_some();
+            }
+        } else {
+            if body.get("thinking").is_none() {
+                body["thinking"] = serde_json::json!({});
+            }
+            body["thinking"]["type"] = serde_json::Value::String(thinking.clone());
+            modified = true;
         }
-        body["thinking"]["type"] = serde_json::Value::String(thinking.clone());
-        modified = true;
     }
 
     if modified {
@@ -127,7 +168,7 @@ pub fn apply_rewrites(
 
 /// Strip request body to essential fields only (pure mode).
 ///
-/// Keeps only: model, messages/contents/input, stream
+/// Keeps only the minimum provider-specific payload required for prompting.
 fn strip_to_essentials(body: &mut serde_json::Value, provider: super::handler::ApiProvider) {
     use super::handler::ApiProvider;
 
@@ -136,17 +177,206 @@ fn strip_to_essentials(body: &mut serde_json::Value, provider: super::handler::A
         None => return,
     };
 
-    let essential_keys: &[&str] = match provider {
-        ApiProvider::Anthropic => &["model", "messages", "stream", "max_tokens"],
-        ApiProvider::OpenAI | ApiProvider::ChatGPT => {
-            &["model", "messages", "input", "stream", "max_output_tokens"]
+    match provider {
+        ApiProvider::Anthropic => {
+            obj.retain(|key, _| ["model", "messages", "stream", "max_tokens"].contains(&key.as_str()));
         }
-        ApiProvider::Google | ApiProvider::GoogleCodeAssist => {
-            &["model", "contents", "stream", "generationConfig"]
+        ApiProvider::OpenAI => {
+            obj.retain(|key, _| {
+                ["model", "messages", "input", "stream", "max_output_tokens"]
+                    .contains(&key.as_str())
+            });
         }
-    };
+        ApiProvider::ChatGPT => {
+            obj.retain(|key, _| ["model", "input"].contains(&key.as_str()));
+        }
+        ApiProvider::Google => {
+            obj.retain(|key, _| ["model", "contents", "stream", "generationConfig"].contains(&key.as_str()));
+        }
+        ApiProvider::GoogleCodeAssist => {
+            let model = obj.remove("model");
+            let project = obj.remove("project");
+            let user_prompt_id = obj.remove("user_prompt_id");
+            let request = obj.remove("request");
 
-    obj.retain(|key, _| essential_keys.contains(&key.as_str()));
+            obj.clear();
+
+            if let Some(model) = model {
+                obj.insert("model".to_string(), model);
+            }
+            if let Some(project) = project {
+                obj.insert("project".to_string(), project);
+            }
+            if let Some(user_prompt_id) = user_prompt_id {
+                obj.insert("user_prompt_id".to_string(), user_prompt_id);
+            }
+            if let Some(mut request) = request {
+                if let Some(request_obj) = request.as_object_mut() {
+                    request_obj.retain(|key, _| {
+                        ["contents", "generationConfig", "session_id"].contains(&key.as_str())
+                    });
+                }
+                obj.insert("request".to_string(), request);
+            }
+        }
+    }
+}
+
+fn strip_system_prompt(
+    body: &mut serde_json::Value,
+    provider: super::handler::ApiProvider,
+) -> bool {
+    use super::handler::ApiProvider;
+
+    match provider {
+        ApiProvider::Anthropic => {
+            body.as_object_mut()
+                .map(|obj| obj.remove("system").is_some())
+                .unwrap_or(false)
+        }
+        ApiProvider::OpenAI | ApiProvider::ChatGPT => {
+            let Some(obj) = body.as_object_mut() else {
+                return false;
+            };
+            let mut modified = obj.remove("system").is_some();
+
+            if let Some(messages) = obj.get_mut("messages").and_then(|v| v.as_array_mut()) {
+                let before = messages.len();
+                messages.retain(|msg| msg.get("role").and_then(|r| r.as_str()) != Some("system"));
+                modified |= messages.len() != before;
+            }
+
+            if let Some(input) = obj.get_mut("input").and_then(|v| v.as_array_mut()) {
+                let before = input.len();
+                input.retain(|msg| msg.get("role").and_then(|r| r.as_str()) != Some("system"));
+                modified |= input.len() != before;
+            }
+
+            modified
+        }
+        ApiProvider::Google => {
+            let Some(obj) = body.as_object_mut() else {
+                return false;
+            };
+            obj.remove("system_instruction").is_some() | obj.remove("systemInstruction").is_some()
+        }
+        ApiProvider::GoogleCodeAssist => {
+            let mut modified = false;
+            if let Some(obj) = body.as_object_mut() {
+                modified |= obj.remove("system_instruction").is_some();
+                modified |= obj.remove("systemInstruction").is_some();
+            }
+            if let Some(request) = object_at_path(body, &["request"]) {
+                modified |= request.remove("system_instruction").is_some();
+                modified |= request.remove("systemInstruction").is_some();
+            }
+
+            modified
+        }
+    }
+}
+
+fn strip_tools(body: &mut serde_json::Value, provider: super::handler::ApiProvider) -> bool {
+    use super::handler::ApiProvider;
+
+    match provider {
+        ApiProvider::Anthropic | ApiProvider::OpenAI | ApiProvider::ChatGPT => {
+            let Some(obj) = body.as_object_mut() else {
+                return false;
+            };
+            let mut modified = false;
+            for key in ["tools", "tool_choice", "parallel_tool_calls"] {
+                modified |= obj.remove(key).is_some();
+            }
+
+            modified
+        }
+        ApiProvider::Google => {
+            let Some(obj) = body.as_object_mut() else {
+                return false;
+            };
+            let mut modified = false;
+            for key in ["tools", "toolConfig", "tool_config"] {
+                modified |= obj.remove(key).is_some();
+            }
+
+            modified
+        }
+        ApiProvider::GoogleCodeAssist => {
+            let mut modified = false;
+            if let Some(obj) = body.as_object_mut() {
+                for key in ["tools", "toolConfig", "tool_config"] {
+                    modified |= obj.remove(key).is_some();
+                }
+            }
+            for key in ["tools", "toolConfig", "tool_config"] {
+                if let Some(request) = object_at_path(body, &["request"]) {
+                    modified |= request.remove(key).is_some();
+                }
+            }
+
+            modified
+        }
+    }
+}
+
+fn ensure_object_path<'a>(
+    value: &'a mut serde_json::Value,
+    path: &[&str],
+) -> Option<&'a mut Map<String, serde_json::Value>> {
+    let mut cursor = value;
+    for key in path {
+        let obj = cursor.as_object_mut()?;
+        cursor = obj
+            .entry((*key).to_string())
+            .or_insert_with(|| serde_json::Value::Object(Map::new()));
+        if !cursor.is_object() {
+            *cursor = serde_json::Value::Object(Map::new());
+        }
+    }
+
+    cursor.as_object_mut()
+}
+
+fn object_at_path<'a>(
+    value: &'a mut serde_json::Value,
+    path: &[&str],
+) -> Option<&'a mut Map<String, serde_json::Value>> {
+    let mut cursor = value;
+    for key in path {
+        cursor = cursor.get_mut(*key)?;
+    }
+
+    cursor.as_object_mut()
+}
+
+fn google_model_supports_thinking(model: &str) -> bool {
+    model.to_ascii_lowercase().contains("flash")
+}
+
+fn strip_google_thinking_config(
+    body: &mut serde_json::Value,
+    provider: super::handler::ApiProvider,
+) -> bool {
+    use super::handler::ApiProvider;
+
+    match provider {
+        ApiProvider::Google => body
+            .get_mut("generationConfig")
+            .and_then(|value| value.as_object_mut())
+            .map(|config| config.remove("thinkingConfig").is_some())
+            .unwrap_or(false),
+        ApiProvider::GoogleCodeAssist => object_at_path(body, &["request", "generationConfig"])
+            .map(|config| config.remove("thinkingConfig").is_some())
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+fn is_code_assist_conversation_body(body: &serde_json::Value) -> bool {
+    body.get("request")
+        .and_then(|request| request.get("contents"))
+        .is_some_and(|contents| contents.is_array())
 }
 
 /// Per-session rewrite config storage.
@@ -230,6 +460,76 @@ mod tests {
     }
 
     #[test]
+    fn temperature_override_google_codeassist() {
+        let mut body = serde_json::json!({
+            "model": "gemini-3-flash-preview",
+            "project": "proj",
+            "user_prompt_id": "prompt-1",
+            "request": {
+                "contents": [],
+                "session_id": "sess-1"
+            }
+        });
+        let config = RewriteConfig {
+            temperature: Some(0.25),
+            ..Default::default()
+        };
+        let modified = apply_rewrites(&mut body, ApiProvider::GoogleCodeAssist, &config);
+        assert!(modified);
+        assert_eq!(body["request"]["generationConfig"]["temperature"], 0.25);
+        assert!(body.get("generationConfig").is_none());
+    }
+
+    #[test]
+    fn model_override_google_codeassist_strips_incompatible_thinking_config() {
+        let mut body = serde_json::json!({
+            "model": "gemini-3-flash-preview",
+            "project": "proj",
+            "user_prompt_id": "prompt-1",
+            "request": {
+                "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+                "generationConfig": {
+                    "thinkingConfig": {
+                        "includeThoughts": true,
+                        "thinkingLevel": "HIGH"
+                    },
+                    "temperature": 1
+                },
+                "session_id": "sess-1"
+            }
+        });
+        let config = RewriteConfig {
+            model_override: Some("gemini-2.5-pro".to_string()),
+            ..Default::default()
+        };
+        let modified = apply_rewrites(&mut body, ApiProvider::GoogleCodeAssist, &config);
+        assert!(modified);
+        assert_eq!(body["model"], "gemini-2.5-pro");
+        assert!(body["request"]["generationConfig"]
+            .get("thinkingConfig")
+            .is_none());
+        assert_eq!(body["request"]["generationConfig"]["temperature"], 1);
+    }
+
+    #[test]
+    fn google_codeassist_non_conversation_requests_are_ignored() {
+        let original = serde_json::json!({
+            "project": "proj"
+        });
+        let mut body = original.clone();
+        let config = RewriteConfig {
+            model_override: Some("gemini-2.5-pro".to_string()),
+            pure_mode: true,
+            strip_system_prompt: true,
+            strip_tools: true,
+            ..Default::default()
+        };
+        let modified = apply_rewrites(&mut body, ApiProvider::GoogleCodeAssist, &config);
+        assert!(!modified);
+        assert_eq!(body, original);
+    }
+
+    #[test]
     fn pure_mode_strips_anthropic() {
         let mut body = serde_json::json!({
             "model": "claude-opus-4-6",
@@ -279,6 +579,67 @@ mod tests {
     }
 
     #[test]
+    fn pure_mode_strips_chatgpt_to_model_and_input() {
+        let mut body = serde_json::json!({
+            "type": "response.create",
+            "model": "gpt-5.4",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+            "stream": true,
+            "instructions": "be helpful",
+            "tools": [{"type": "function"}]
+        });
+        let config = RewriteConfig {
+            pure_mode: true,
+            ..Default::default()
+        };
+
+        let modified = apply_rewrites(&mut body, ApiProvider::ChatGPT, &config);
+
+        assert!(modified);
+        let obj = body.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert!(obj.get("model").is_some());
+        assert!(obj.get("input").is_some());
+        assert!(obj.get("stream").is_none());
+        assert!(obj.get("instructions").is_none());
+        assert!(obj.get("tools").is_none());
+    }
+
+    #[test]
+    fn pure_mode_strips_google_codeassist() {
+        let mut body = serde_json::json!({
+            "model": "gemini-3-flash-preview",
+            "project": "proj",
+            "user_prompt_id": "prompt-1",
+            "request": {
+                "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+                "systemInstruction": {"parts": [{"text": "secret"}]},
+                "tools": [{"functionDeclarations": []}],
+                "generationConfig": {"temperature": 1},
+                "session_id": "sess-1",
+                "metadata": {"foo": "bar"}
+            },
+            "trace_id": "trace-1"
+        });
+        let config = RewriteConfig {
+            pure_mode: true,
+            ..Default::default()
+        };
+        let modified = apply_rewrites(&mut body, ApiProvider::GoogleCodeAssist, &config);
+        assert!(modified);
+        assert_eq!(body["model"], "gemini-3-flash-preview");
+        assert_eq!(body["project"], "proj");
+        assert_eq!(body["user_prompt_id"], "prompt-1");
+        assert!(body.get("trace_id").is_none());
+        assert!(body["request"]["contents"].is_array());
+        assert!(body["request"]["generationConfig"].is_object());
+        assert_eq!(body["request"]["session_id"], "sess-1");
+        assert!(body["request"].get("systemInstruction").is_none());
+        assert!(body["request"].get("tools").is_none());
+        assert!(body["request"].get("metadata").is_none());
+    }
+
+    #[test]
     fn inactive_config_no_change() {
         let mut body = serde_json::json!({"model": "test"});
         let config = RewriteConfig::default();
@@ -294,10 +655,104 @@ mod tests {
             max_tokens: Some(8192),
             thinking_type: Some("enabled".to_string()),
             pure_mode: true,
+            strip_system_prompt: true,
+            strip_tools: true,
         };
         let json = serde_json::to_string(&config).unwrap();
         let parsed: RewriteConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.model_override, config.model_override);
         assert!(parsed.pure_mode);
+        assert!(parsed.strip_system_prompt);
+        assert!(parsed.strip_tools);
+    }
+
+    #[test]
+    fn strip_system_prompt_anthropic() {
+        let mut body = serde_json::json!({
+            "model": "claude-sonnet-4-6",
+            "system": "secret system",
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let config = RewriteConfig {
+            strip_system_prompt: true,
+            ..Default::default()
+        };
+        let modified = apply_rewrites(&mut body, ApiProvider::Anthropic, &config);
+        assert!(modified);
+        assert!(body.get("system").is_none());
+    }
+
+    #[test]
+    fn strip_tools_openai() {
+        let mut body = serde_json::json!({
+            "model": "gpt-4o",
+            "messages": [],
+            "tools": [{"type": "function"}],
+            "tool_choice": "auto",
+            "parallel_tool_calls": true
+        });
+        let config = RewriteConfig {
+            strip_tools: true,
+            ..Default::default()
+        };
+        let modified = apply_rewrites(&mut body, ApiProvider::OpenAI, &config);
+        assert!(modified);
+        assert!(body.get("tools").is_none());
+        assert!(body.get("tool_choice").is_none());
+        assert!(body.get("parallel_tool_calls").is_none());
+    }
+
+    #[test]
+    fn thinking_remove_deletes_block() {
+        let mut body = serde_json::json!({
+            "model": "claude-sonnet-4-6",
+            "messages": [],
+            "thinking": {"type": "enabled"}
+        });
+        let config = RewriteConfig {
+            thinking_type: Some("remove".to_string()),
+            ..Default::default()
+        };
+        let modified = apply_rewrites(&mut body, ApiProvider::Anthropic, &config);
+        assert!(modified);
+        assert!(body.get("thinking").is_none());
+    }
+
+    #[test]
+    fn strip_system_prompt_google_codeassist() {
+        let mut body = serde_json::json!({
+            "model": "gemini-3-flash-preview",
+            "request": {
+                "contents": [],
+                "systemInstruction": {"parts": [{"text": "secret"}]}
+            }
+        });
+        let config = RewriteConfig {
+            strip_system_prompt: true,
+            ..Default::default()
+        };
+        let modified = apply_rewrites(&mut body, ApiProvider::GoogleCodeAssist, &config);
+        assert!(modified);
+        assert!(body["request"].get("systemInstruction").is_none());
+    }
+
+    #[test]
+    fn strip_tools_google_codeassist() {
+        let mut body = serde_json::json!({
+            "model": "gemini-3-flash-preview",
+            "request": {
+                "contents": [],
+                "tools": [{"functionDeclarations": []}],
+                "toolConfig": {"mode": "auto"}
+            }
+        });
+        let config = RewriteConfig {
+            strip_tools: true,
+            ..Default::default()
+        };
+        let modified = apply_rewrites(&mut body, ApiProvider::GoogleCodeAssist, &config);
+        assert!(modified);
+        assert!(body["request"].get("tools").is_none());
+        assert!(body["request"].get("toolConfig").is_none());
     }
 }

--- a/server/src/proxy/websocket.rs
+++ b/server/src/proxy/websocket.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 
 use futures_util::{SinkExt, StreamExt};
 use tokio_tungstenite::tungstenite::Message as TungMessage;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use super::mitm::{self, ApiRequestLog};
 
@@ -51,19 +51,26 @@ pub async fn relay_frames(
 
             match msg {
                 axum::extract::ws::Message::Text(text) => {
+                    let outbound = transform_outgoing_text_frame(
+                        text.as_ref(),
+                        &url_for_out,
+                        session_for_out.as_deref(),
+                        &state_for_out,
+                    );
+
                     // Log text frame as WS-OUT
                     log_ws_frame(
                         &session_for_out,
                         &url_for_out,
                         "WS-OUT",
-                        Some(text.as_ref()),
-                        text.len(),
+                        Some(&outbound),
+                        outbound.len(),
                         &state_for_out,
                     )
                     .await;
 
                     if upstream_tx
-                        .send(TungMessage::Text(text.as_str().into()))
+                        .send(TungMessage::Text(outbound.into()))
                         .await
                         .is_err()
                     {
@@ -197,6 +204,70 @@ pub async fn relay_frames(
     info!(url = %url_for_out, "WebSocket relay ended");
 }
 
+fn transform_outgoing_text_frame(
+    text: &str,
+    url: &str,
+    session_id: Option<&str>,
+    state: &super::handler::ProxyState,
+) -> String {
+    let Some(session_id) = session_id else {
+        return text.to_string();
+    };
+
+    let Some(provider) = detect_ws_provider(url) else {
+        return text.to_string();
+    };
+
+    let Ok(mut body_json) = serde_json::from_str::<serde_json::Value>(text) else {
+        return text.to_string();
+    };
+
+    if body_json.get("type").and_then(|value| value.as_str()) != Some("response.create") {
+        return text.to_string();
+    }
+
+    let mut modified = false;
+
+    let inject_config = state.inject_store.get(session_id);
+    let injection_text = super::inject::build_injection(&inject_config);
+    if !injection_text.is_empty()
+        && super::inject::inject_into_body(&mut body_json, provider, &injection_text)
+    {
+        modified = true;
+    }
+
+    let rewrite_config = state.rewrite_store.get(session_id);
+    if rewrite_config.is_active()
+        && super::rewrite::apply_rewrites(&mut body_json, provider, &rewrite_config)
+    {
+        modified = true;
+    }
+
+    if !modified {
+        return text.to_string();
+    }
+
+    match serde_json::to_string(&body_json) {
+        Ok(serialized) => serialized,
+        Err(error) => {
+            warn!(error = %error, url = %url, "failed to serialize transformed websocket frame");
+            text.to_string()
+        }
+    }
+}
+
+fn detect_ws_provider(url: &str) -> Option<super::handler::ApiProvider> {
+    let parsed = reqwest::Url::parse(url).ok()?;
+    let host = parsed.host_str()?;
+    let path = parsed.path();
+
+    if host == "chatgpt.com" && path.starts_with("/backend-api/") {
+        return Some(super::handler::ApiProvider::ChatGPT);
+    }
+
+    None
+}
+
 /// Log a single WebSocket frame as an ApiRequestLog entry.
 ///
 /// Text frames include the (redacted) body content; binary frames log only metadata.
@@ -284,6 +355,7 @@ pub fn is_websocket_upgrade(headers: &axum::http::HeaderMap) -> bool {
 mod tests {
     use super::*;
     use axum::http::HeaderMap;
+    use super::super::handler::ApiProvider;
 
     #[test]
     fn detects_websocket_upgrade_headers() {
@@ -332,25 +404,7 @@ mod tests {
 
     #[tokio::test]
     async fn log_ws_frame_text_redacts_keys() {
-        use std::collections::{HashMap, VecDeque};
-        use tokio::sync::{RwLock, broadcast};
-
-        let (event_tx, _rx) = broadcast::channel(16);
-        let state = Arc::new(super::super::handler::ProxyState {
-            client: reqwest::Client::new(),
-            event_tx,
-            captured: RwLock::new(VecDeque::new()),
-            intercept_modes: RwLock::new(HashMap::new()),
-            pending_intercepts: RwLock::new(HashMap::new()),
-            pending_response_intercepts: RwLock::new(HashMap::new()),
-            pending_images: RwLock::new(HashMap::new()),
-            ca: None,
-            network_rules: Arc::new(super::super::rules::NetworkRulesEngine::new()),
-            proxy_modes: super::super::modes::ProxyModeStore::new(),
-            inject_store: super::super::inject::InjectStore::new(),
-            rewrite_store: super::super::rewrite::RewriteStore::new(),
-            key_store: super::super::keys::KeyStore::new(),
-        });
+        let state = Arc::new(test_proxy_state());
 
         let session = Some("test-session".to_string());
         let body_with_key = r#"{"key": "sk-ant-api03-secret123"}"#;
@@ -375,25 +429,7 @@ mod tests {
 
     #[tokio::test]
     async fn log_ws_frame_binary_shows_metadata() {
-        use std::collections::{HashMap, VecDeque};
-        use tokio::sync::{RwLock, broadcast};
-
-        let (event_tx, _rx) = broadcast::channel(16);
-        let state = Arc::new(super::super::handler::ProxyState {
-            client: reqwest::Client::new(),
-            event_tx,
-            captured: RwLock::new(VecDeque::new()),
-            intercept_modes: RwLock::new(HashMap::new()),
-            pending_intercepts: RwLock::new(HashMap::new()),
-            pending_response_intercepts: RwLock::new(HashMap::new()),
-            pending_images: RwLock::new(HashMap::new()),
-            ca: None,
-            network_rules: Arc::new(super::super::rules::NetworkRulesEngine::new()),
-            proxy_modes: super::super::modes::ProxyModeStore::new(),
-            inject_store: super::super::inject::InjectStore::new(),
-            rewrite_store: super::super::rewrite::RewriteStore::new(),
-            key_store: super::super::keys::KeyStore::new(),
-        });
+        let state = Arc::new(test_proxy_state());
 
         let session = Some("test-session".to_string());
 
@@ -413,5 +449,139 @@ mod tests {
         assert_eq!(entry.method, "WS-IN");
         assert!(entry.response_body.contains("binary frame"));
         assert!(entry.response_body.contains("4096"));
+    }
+
+    #[test]
+    fn transforms_codex_ws_response_create_with_inject_and_rewrite() {
+        let state = test_proxy_state();
+        state.inject_store.set(
+            "session-1".to_string(),
+            super::super::inject::InjectConfig {
+                presets: vec![],
+                custom_text: Some("ws inject".to_string()),
+            },
+        );
+        state.rewrite_store.set(
+            "session-1".to_string(),
+            super::super::rewrite::RewriteConfig {
+                model_override: Some("gpt-4o".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let original = serde_json::json!({
+            "type": "response.create",
+            "model": "gpt-5.4",
+            "instructions": "existing instructions",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+        });
+
+        let transformed = transform_outgoing_text_frame(
+            &serde_json::to_string(&original).unwrap(),
+            "wss://chatgpt.com/backend-api/codex/responses",
+            Some("session-1"),
+            &state,
+        );
+
+        let parsed: serde_json::Value = serde_json::from_str(&transformed).unwrap();
+        assert_eq!(parsed["model"], "gpt-4o");
+        let instructions = parsed["instructions"].as_str().unwrap();
+        assert!(instructions.contains("existing instructions"));
+        assert!(instructions.contains("ws inject"));
+    }
+
+    #[test]
+    fn transforms_codex_ws_response_create_with_pure_mode() {
+        let state = test_proxy_state();
+        state.rewrite_store.set(
+            "session-1".to_string(),
+            super::super::rewrite::RewriteConfig {
+                pure_mode: true,
+                ..Default::default()
+            },
+        );
+
+        let original = serde_json::json!({
+            "type": "response.create",
+            "model": "gpt-5.4",
+            "stream": true,
+            "instructions": "existing instructions",
+            "tools": [{"type": "function"}],
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+        });
+
+        let transformed = transform_outgoing_text_frame(
+            &serde_json::to_string(&original).unwrap(),
+            "wss://chatgpt.com/backend-api/codex/responses",
+            Some("session-1"),
+            &state,
+        );
+
+        let parsed: serde_json::Value = serde_json::from_str(&transformed).unwrap();
+        let obj = parsed.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert_eq!(parsed["model"], "gpt-5.4");
+        assert!(parsed["input"].is_array());
+        assert!(parsed.get("stream").is_none());
+        assert!(parsed.get("instructions").is_none());
+        assert!(parsed.get("tools").is_none());
+    }
+
+    #[test]
+    fn leaves_non_response_create_ws_frames_unchanged() {
+        let state = test_proxy_state();
+        state.inject_store.set(
+            "session-1".to_string(),
+            super::super::inject::InjectConfig {
+                presets: vec![],
+                custom_text: Some("ws inject".to_string()),
+            },
+        );
+
+        let original = serde_json::json!({
+            "type": "response.cancel",
+            "instructions": "existing instructions",
+        });
+        let original_text = serde_json::to_string(&original).unwrap();
+
+        let transformed = transform_outgoing_text_frame(
+            &original_text,
+            "wss://chatgpt.com/backend-api/codex/responses",
+            Some("session-1"),
+            &state,
+        );
+
+        assert_eq!(transformed, original_text);
+    }
+
+    #[test]
+    fn detects_chatgpt_ws_provider() {
+        assert_eq!(
+            detect_ws_provider("wss://chatgpt.com/backend-api/codex/responses"),
+            Some(ApiProvider::ChatGPT)
+        );
+        assert_eq!(detect_ws_provider("wss://example.com/ws"), None);
+    }
+
+    fn test_proxy_state() -> super::super::handler::ProxyState {
+        use std::collections::{HashMap, VecDeque};
+        use tokio::sync::{broadcast, RwLock};
+
+        let (event_tx, _rx) = broadcast::channel(16);
+        super::super::handler::ProxyState {
+            client: reqwest::Client::new(),
+            event_tx,
+            captured: RwLock::new(VecDeque::new()),
+            intercept_modes: RwLock::new(HashMap::new()),
+            pending_intercepts: RwLock::new(HashMap::new()),
+            pending_response_intercepts: RwLock::new(HashMap::new()),
+            pending_images: RwLock::new(HashMap::new()),
+            ca: None,
+            network_rules: Arc::new(super::super::rules::NetworkRulesEngine::new()),
+            proxy_modes: super::super::modes::ProxyModeStore::new(),
+            inject_store: super::super::inject::InjectStore::new(),
+            rewrite_store: super::super::rewrite::RewriteStore::new(),
+            key_store: super::super::keys::KeyStore::new(),
+        }
     }
 }

--- a/server/src/proxy/websocket.rs
+++ b/server/src/proxy/websocket.rs
@@ -353,9 +353,9 @@ pub fn is_websocket_upgrade(headers: &axum::http::HeaderMap) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::super::handler::ApiProvider;
     use super::*;
     use axum::http::HeaderMap;
-    use super::super::handler::ApiProvider;
 
     #[test]
     fn detects_websocket_upgrade_headers() {
@@ -565,7 +565,7 @@ mod tests {
 
     fn test_proxy_state() -> super::super::handler::ProxyState {
         use std::collections::{HashMap, VecDeque};
-        use tokio::sync::{broadcast, RwLock};
+        use tokio::sync::{RwLock, broadcast};
 
         let (event_tx, _rx) = broadcast::channel(16);
         super::super::handler::ProxyState {

--- a/server/src/session/managed.rs
+++ b/server/src/session/managed.rs
@@ -35,6 +35,31 @@ fn state_from_u8(v: u8) -> SessionState {
     }
 }
 
+fn build_exec_argv(
+    binary: &str,
+    auto_approve: bool,
+    codex_chatgpt_base_url: Option<&str>,
+) -> Result<(CString, Vec<CString>), SessionError> {
+    let c_binary = CString::new(binary).map_err(|e| SessionError::PtySpawn(e.to_string()))?;
+    let mut c_args = vec![c_binary.clone()];
+
+    if auto_approve && binary == "claude" {
+        c_args.push(CString::new("--dangerously-skip-permissions").unwrap());
+    }
+
+    if binary == "codex"
+        && let Some(chatgpt_base_url) = codex_chatgpt_base_url
+    {
+        c_args.push(CString::new("--config").unwrap());
+        c_args.push(
+            CString::new(format!("chatgpt_base_url=\"{chatgpt_base_url}\""))
+                .map_err(|e| SessionError::PtySpawn(e.to_string()))?,
+        );
+    }
+
+    Ok((c_binary, c_args))
+}
+
 /// PTY output patterns used to detect Breathing Orb state.
 /// Currently used in tests; will drive fine-grained state detection in WP-9.
 #[allow(dead_code)]
@@ -103,6 +128,7 @@ impl ManagedSession {
         // MAX_OUTPUT_TOKENS, AUTO_CONNECT_IDE, etc. — causing it to run
         // headless instead of showing an interactive TUI prompt.
         let mut env_vars: Vec<(String, String)> = Vec::new();
+        let mut codex_chatgpt_base_url: Option<String> = None;
         env_vars.push(("TERM".to_string(), "xterm-256color".to_string()));
         // Clear ALL Claude-related env vars to ensure fresh interactive session
         env_vars.push(("CLAUDECODE".to_string(), String::new()));
@@ -130,6 +156,11 @@ impl ManagedSession {
                 "OPENAI_BASE_URL".to_string(),
                 format!("{base}/s/{sid}/backend-api/codex"),
             ));
+            // Codex uses `chatgpt_base_url` config (not an env var) for
+            // analytics, plugins, WHAM, and other ChatGPT-backend endpoints.
+            // Route those through the same per-session reverse proxy so telemetry
+            // stays visible and proxy modes can block it.
+            codex_chatgpt_base_url = Some(format!("{base}/s/{sid}/backend-api/"));
             // Gemini CLI: per-session proxy URL for Code Assist backend
             // CODE_ASSIST_ENDPOINT covers control-plane calls (v1internal:*)
             // GOOGLE_GEMINI_BASE_URL covers the actual LLM/generative calls
@@ -190,14 +221,9 @@ impl ManagedSession {
             }
         }
 
-        // Prepare CStrings for exec (must be done before fork — no allocations after fork)
-        let c_binary = CString::new(binary).map_err(|e| SessionError::PtySpawn(e.to_string()))?;
-        let c_args: Vec<CString> = if auto_approve && binary == "claude" {
-            let flag = CString::new("--dangerously-skip-permissions").unwrap();
-            vec![c_binary.clone(), flag]
-        } else {
-            vec![c_binary.clone()]
-        };
+        // Prepare argv before fork (no heap allocation after fork).
+        let (c_binary, c_args) =
+            build_exec_argv(binary, auto_approve, codex_chatgpt_base_url.as_deref())?;
 
         let working_dir_owned = working_dir.to_path_buf();
 
@@ -607,6 +633,44 @@ mod tests {
         });
 
         (session, event_rx)
+    }
+
+    #[test]
+    fn codex_exec_argv_includes_chatgpt_base_url_override() {
+        let (_, args) = build_exec_argv(
+            "codex",
+            false,
+            Some("http://localhost:4434/s/test-session/backend-api/"),
+        )
+        .unwrap();
+
+        let rendered: Vec<String> = args
+            .iter()
+            .map(|arg| arg.to_str().unwrap().to_string())
+            .collect();
+
+        assert_eq!(rendered[0], "codex");
+        assert!(rendered.contains(&"--config".to_string()));
+        assert!(rendered.contains(
+            &"chatgpt_base_url=\"http://localhost:4434/s/test-session/backend-api/\"".to_string()
+        ));
+    }
+
+    #[test]
+    fn claude_exec_argv_preserves_auto_approve_flag() {
+        let (_, args) = build_exec_argv("claude", true, None).unwrap();
+        let rendered: Vec<String> = args
+            .iter()
+            .map(|arg| arg.to_str().unwrap().to_string())
+            .collect();
+
+        assert_eq!(
+            rendered,
+            vec![
+                "claude".to_string(),
+                "--dangerously-skip-permissions".to_string()
+            ]
+        );
     }
 
     #[tokio::test]

--- a/server/whisper/server.py
+++ b/server/whisper/server.py
@@ -1,0 +1,337 @@
+"""
+Streaming Whisper transcription sidecar.
+
+Receives raw PCM 16-bit LE mono 16 kHz audio over WebSocket,
+accumulates a buffer, and periodically transcribes with faster-whisper.
+Sends back partial/final JSON text frames.
+
+Env vars:
+  WHISPER_PORT         (default 8081)
+  WHISPER_MODEL_SIZE   (default small)
+  WHISPER_LANGUAGE     (default en)
+  WHISPER_DEVICE       (default cuda, falls back to cpu)
+  WHISPER_COMPUTE_TYPE (default float16 for cuda, int8 for cpu)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import faulthandler
+import glob
+import logging
+import os
+import signal
+import struct
+import sys
+import time
+from contextlib import asynccontextmanager
+
+# Enable faulthandler to dump traceback on SIGSEGV/SIGABRT
+faulthandler.enable(file=sys.stderr)
+
+# ---------------------------------------------------------------------------
+# Ensure nvidia pip-installed libraries (cuDNN 9, cuBLAS, etc.) are discoverable.
+# CTranslate2/faster-whisper load .so via dlopen which searches LD_LIBRARY_PATH.
+# The Rust spawner should set LD_LIBRARY_PATH before starting this process.
+# As a fallback, we also set it here and re-exec if it was missing.
+# ---------------------------------------------------------------------------
+_nvidia_base = os.path.join(sys.prefix, "lib", f"python{sys.version_info.major}.{sys.version_info.minor}", "site-packages", "nvidia")
+if os.path.isdir(_nvidia_base):
+    _nvidia_lib_dirs = sorted(glob.glob(os.path.join(_nvidia_base, "*", "lib")))
+    if _nvidia_lib_dirs:
+        _needed = os.pathsep.join(_nvidia_lib_dirs)
+        _current = os.environ.get("LD_LIBRARY_PATH", "")
+        if _nvidia_lib_dirs[0] not in _current:
+            # LD_LIBRARY_PATH was not set — set it and re-exec so dlopen sees it
+            os.environ["LD_LIBRARY_PATH"] = f"{_needed}{os.pathsep}{_current}" if _current else _needed
+            os.execv(sys.executable, [sys.executable] + sys.argv)
+
+import numpy as np
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger("whisper-sidecar")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    stream=sys.stderr,
+)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+PORT = int(os.environ.get("WHISPER_PORT", "8082"))
+MODEL_SIZE = os.environ.get("WHISPER_MODEL_SIZE", "small")
+LANGUAGE = os.environ.get("WHISPER_LANGUAGE", "de")
+# NOTE: CUDA requires cuDNN 9 for CTranslate2 >=4.5. If cuDNN 9 is not installed,
+# the encoder will SIGABRT. Use "cpu" as safe default, set WHISPER_DEVICE=cuda
+# only when cuDNN 9 is confirmed available.
+DEVICE = os.environ.get("WHISPER_DEVICE", "cuda")
+COMPUTE_TYPE = os.environ.get("WHISPER_COMPUTE_TYPE", "")
+
+# Transcription triggers
+SAMPLE_RATE = 16000
+BYTES_PER_SAMPLE = 2  # int16
+TRANSCRIBE_INTERVAL_BYTES = int(SAMPLE_RATE * BYTES_PER_SAMPLE * 1.5)  # 1.5s
+SILENCE_TIMEOUT_S = 2.0  # auto-stop after 2s silence
+
+# ---------------------------------------------------------------------------
+# Model singleton
+# ---------------------------------------------------------------------------
+_model = None
+_actual_device = None
+
+
+def get_model():
+    """Load model on first call, with GPU→CPU fallback."""
+    global _model, _actual_device
+    if _model is not None:
+        return _model
+
+    from faster_whisper import WhisperModel
+
+    device = DEVICE
+    compute = COMPUTE_TYPE or ("float16" if device == "cuda" else "int8")
+
+    try:
+        logger.info("Loading model=%s device=%s compute=%s", MODEL_SIZE, device, compute)
+        _model = WhisperModel(MODEL_SIZE, device=device, compute_type=compute)
+        _actual_device = device
+        logger.info("Model loaded on %s", device)
+    except Exception as exc:
+        if device == "cuda":
+            logger.warning("CUDA failed (%s), falling back to CPU", exc)
+            device = "cpu"
+            compute = COMPUTE_TYPE or "int8"
+            _model = WhisperModel(MODEL_SIZE, device=device, compute_type=compute)
+            _actual_device = device
+            logger.info("Model loaded on CPU (fallback)")
+        else:
+            raise
+
+    return _model
+
+
+# ---------------------------------------------------------------------------
+# Silero VAD (standalone, for silence detection on raw PCM)
+# ---------------------------------------------------------------------------
+_vad_model = None
+_vad_utils = None
+
+
+def get_vad():
+    """Load Silero VAD model (lazy)."""
+    global _vad_model, _vad_utils
+    if _vad_model is not None:
+        return _vad_model, _vad_utils
+
+    import torch
+
+    torch.set_num_threads(1)
+    model, utils = torch.hub.load(
+        repo_or_dir="snakers4/silero-vad",
+        model="silero_vad",
+        trust_repo=True,
+    )
+    _vad_model = model
+    _vad_utils = utils
+    logger.info("Silero VAD loaded")
+    return _vad_model, _vad_utils
+
+
+def check_speech(pcm_int16: bytes) -> bool:
+    """Return True if speech detected in the last chunk."""
+    import torch
+
+    try:
+        model, _ = get_vad()
+        audio = np.frombuffer(pcm_int16, dtype=np.int16).astype(np.float32) / 32768.0
+        # Silero expects 16kHz, 512-sample windows
+        tensor = torch.from_numpy(audio)
+        # Process in 512-sample windows, return True if ANY window has speech
+        window = 512
+        for i in range(0, len(tensor) - window + 1, window):
+            chunk = tensor[i : i + window]
+            prob = model(chunk, SAMPLE_RATE).item()
+            if prob > 0.5:
+                return True
+        return False
+    except Exception as exc:
+        logger.debug("VAD check failed: %s", exc)
+        return True  # assume speech on error
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app
+# ---------------------------------------------------------------------------
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Eagerly load model at startup
+    loop = asyncio.get_event_loop()
+    await loop.run_in_executor(None, get_model)
+    await loop.run_in_executor(None, get_vad)
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["GET"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+async def health():
+    model = get_model()
+    return JSONResponse(
+        {
+            "status": "ready",
+            "model": MODEL_SIZE,
+            "device": _actual_device or "unknown",
+            "language": LANGUAGE,
+        }
+    )
+
+
+@app.websocket("/ws/transcribe")
+async def ws_transcribe(ws: WebSocket):
+    await ws.accept()
+    logger.info("Client connected")
+
+    audio_buffer = bytearray()
+    last_speech_time = time.monotonic()
+    last_transcribe_pos = 0
+    accumulated_text = ""
+    running = True
+
+    try:
+        while running:
+            try:
+                data = await asyncio.wait_for(ws.receive(), timeout=0.5)
+            except asyncio.TimeoutError:
+                # Check silence timeout
+                if time.monotonic() - last_speech_time > SILENCE_TIMEOUT_S and len(audio_buffer) > 0:
+                    # Final transcription
+                    final_text = await _transcribe_buffer(audio_buffer)
+                    if final_text:
+                        await ws.send_json({"type": "final", "text": final_text})
+                    else:
+                        await ws.send_json({"type": "final", "text": accumulated_text})
+                    await ws.send_json({"type": "silence_detected"})
+                    running = False
+                continue
+
+            if "bytes" in data and data["bytes"]:
+                pcm_data = data["bytes"]
+                audio_buffer.extend(pcm_data)
+                if len(audio_buffer) <= 6400 or len(audio_buffer) % 32000 == 0:
+                    logger.info("Buffer: %d bytes (%.2fs)", len(audio_buffer), len(audio_buffer) / (SAMPLE_RATE * BYTES_PER_SAMPLE))
+
+                # VAD check on incoming chunk
+                has_speech = await asyncio.get_event_loop().run_in_executor(
+                    None, check_speech, pcm_data
+                )
+                if has_speech:
+                    last_speech_time = time.monotonic()
+
+                # Transcribe periodically
+                new_bytes = len(audio_buffer) - last_transcribe_pos
+                if new_bytes >= TRANSCRIBE_INTERVAL_BYTES:
+                    logger.info("Triggering transcription at %d bytes", len(audio_buffer))
+                    text = await _transcribe_buffer(audio_buffer)
+                    logger.info("Transcription done, sending partial: %r", (text or "")[:80])
+                    if text and text != accumulated_text:
+                        accumulated_text = text
+                        await ws.send_json({"type": "partial", "text": text})
+                    last_transcribe_pos = len(audio_buffer)
+
+            elif "text" in data and data["text"]:
+                import json
+
+                try:
+                    msg = json.loads(data["text"])
+                    if msg.get("type") == "stop":
+                        # Client requested stop — do final transcription
+                        final_text = await _transcribe_buffer(audio_buffer)
+                        await ws.send_json(
+                            {"type": "final", "text": final_text or accumulated_text}
+                        )
+                        running = False
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+    except WebSocketDisconnect:
+        logger.info("Client disconnected")
+    except Exception as exc:
+        logger.error("WebSocket error: %s", exc, exc_info=True)
+        try:
+            await ws.send_json({"type": "error", "message": str(exc)})
+        except Exception:
+            pass
+    finally:
+        logger.info("Session ended, buffer=%d bytes, text=%r", len(audio_buffer), accumulated_text)
+
+
+async def _transcribe_buffer(buffer: bytearray) -> str:
+    """Run faster-whisper on accumulated PCM buffer."""
+    if len(buffer) < SAMPLE_RATE * BYTES_PER_SAMPLE * 0.3:
+        return ""  # too short (<0.3s)
+
+    audio = np.frombuffer(bytes(buffer), dtype=np.int16).astype(np.float32) / 32768.0
+
+    loop = asyncio.get_event_loop()
+    text = await loop.run_in_executor(None, _sync_transcribe, audio)
+    return text
+
+
+def _sync_transcribe(audio: np.ndarray) -> str:
+    """Synchronous transcription (runs in thread pool)."""
+    try:
+        model = get_model()
+        logger.info("Transcribing %d samples (%.2fs)", len(audio), len(audio) / SAMPLE_RATE)
+        segments, info = model.transcribe(
+            audio,
+            language=LANGUAGE,
+            beam_size=1,  # fastest
+            best_of=1,
+            temperature=0.0,
+            condition_on_previous_text=False,
+            # CRITICAL: vad_filter=True causes SIGABRT via ONNX Runtime GPU discovery
+            # bug on systems with virtual DRM devices missing /sys/class/drm/cardN/device/vendor.
+            # We use our own Silero VAD for silence detection instead.
+            vad_filter=False,
+            without_timestamps=True,
+        )
+        # CRITICAL: consume generator immediately to release GPU resources
+        parts = [seg.text.strip() for seg in segments]
+        result = " ".join(p for p in parts if p)
+        logger.info("Transcription result: %r", result[:120] if result else "(empty)")
+        return result
+    except Exception as exc:
+        logger.error("Transcription CRASHED: %s", exc, exc_info=True)
+        import traceback
+        traceback.print_exc(file=sys.stderr)
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import uvicorn
+
+    # Handle SIGTERM gracefully (from Rust parent)
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+
+    logger.info("Starting whisper sidecar on port %d", PORT)
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=PORT,
+        log_level="warning",
+        access_log=False,
+    )


### PR DESCRIPTION
## Summary
- finalize the proxy/network retest fixes and custom configuration UI wiring
- add persisted encrypted API key storage plus live key management UI
- guard the whisper sidecar spawn path so a busy `:8082` port no longer causes a respawn loop

## Verification
- `playwright-cli -s=noaide` targeted retests for Task 411, including `T800-T804`
- `pnpm run typecheck`
- `pnpm run lint` (20 warnings, 0 errors)
- `cargo remote -c -- build -p noaide-server`