### PR TITLE
feat: verify issue 94 managed plan workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,9 +3430,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/frontend/e2e/smoke.test.ts
+++ b/frontend/e2e/smoke.test.ts
@@ -63,7 +63,7 @@ test.describe("noaide smoke tests", () => {
   test("dependency graph has clickable nodes", async ({ page }) => {
     await page.getByTestId("tab-plan").click();
     await page.getByTestId("sidebar-view-dependencies").click();
-    const node = page.locator("[data-testid^='dep-node-']").first();
+    const node = page.locator("[data-testid^='dependency-node-']").first();
     await expect(node).toBeVisible({ timeout: 5000 });
     // Click should change opacity of non-downstream nodes
     await node.dispatchEvent("click");

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,7 @@
         "@solidjs/router": "^0.15.0",
         "@types/dompurify": "^3.2.0",
         "ansi-to-html": "^0.7.2",
-        "dompurify": "^3.3.3",
+        "dompurify": "^3.4.1",
         "fzstd": "^0.1.1",
         "marked": "^17.0.3",
         "qrcode": "^1.5.4",
@@ -3077,9 +3077,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "@solidjs/router": "^0.15.0",
     "@types/dompurify": "^3.2.0",
     "ansi-to-html": "^0.7.2",
-    "dompurify": "^3.3.3",
+    "dompurify": "^3.4.1",
     "fzstd": "^0.1.1",
     "marked": "^17.0.3",
     "qrcode": "^1.5.4",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: ^0.7.2
         version: 0.7.2
       dompurify:
-        specifier: ^3.3.3
-        version: 3.3.3
+        specifier: ^3.4.1
+        version: 3.4.1
       fzstd:
         specifier: ^0.1.1
         version: 0.1.1
@@ -1073,8 +1073,8 @@ packages:
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.1:
+    resolution: {integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==}
 
   electron-to-chromium@1.5.302:
     resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
@@ -2459,7 +2459,7 @@ snapshots:
 
   '@types/dompurify@3.2.0':
     dependencies:
-      dompurify: 3.3.3
+      dompurify: 3.4.1
 
   '@types/estree@1.0.8': {}
 
@@ -2818,7 +2818,7 @@ snapshots:
 
   dom-accessibility-api@0.5.16: {}
 
-  dompurify@3.3.3:
+  dompurify@3.4.1:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 

--- a/frontend/src/components/sessions/SessionList.tsx
+++ b/frontend/src/components/sessions/SessionList.tsx
@@ -305,6 +305,7 @@ export default function SessionList() {
   const [spawning, setSpawning] = createSignal(false);
   const [memUsage, setMemUsage] = createSignal("");
   const [workingDir, setWorkingDir] = createSignal("/work");
+  const [autoApprove, setAutoApprove] = createSignal(false);
   const [browseDirs, setBrowseDirs] = createSignal<{ name: string; path: string }[]>([]);
   const [showBrowser, setShowBrowser] = createSignal(false);
   const [browseLoading, setBrowseLoading] = createSignal(false);
@@ -430,7 +431,7 @@ export default function SessionList() {
       const res = await fetch(`${base}/api/sessions/managed`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ working_dir: workingDir(), cli_type: cliType }),
+        body: JSON.stringify({ working_dir: workingDir(), cli_type: cliType, auto_approve: autoApprove() }),
       });
       if (res.ok) {
         const data = await res.json();
@@ -938,6 +939,27 @@ export default function SessionList() {
                   </Show>
                 </div>
               </Show>
+              <label
+                style={{
+                  display: "flex",
+                  "align-items": "center",
+                  gap: "6px",
+                  "margin-top": "6px",
+                  color: "var(--ctp-overlay0)",
+                  "font-size": "10px",
+                  "font-family": "var(--font-mono)",
+                  cursor: "pointer",
+                }}
+              >
+                <input
+                  data-testid="auto-approve-toggle"
+                  type="checkbox"
+                  checked={autoApprove()}
+                  onChange={(e) => setAutoApprove(e.currentTarget.checked)}
+                  style={{ cursor: "pointer" }}
+                />
+                Auto-approve Claude tool prompts
+              </label>
             </div>
 
             <For each={CLI_OPTIONS}>

--- a/frontend/src/components/sessions/SessionList.tsx
+++ b/frontend/src/components/sessions/SessionList.tsx
@@ -854,6 +854,7 @@ export default function SessionList() {
               </div>
               <div style={{ display: "flex", gap: "4px" }}>
                 <input
+                  data-testid="working-dir-input"
                   type="text"
                   value={workingDir()}
                   onInput={(e) => setWorkingDir(e.currentTarget.value)}
@@ -872,6 +873,7 @@ export default function SessionList() {
                   }}
                 />
                 <button
+                  data-testid="working-dir-browse-btn"
                   onClick={() => browseDirectory(workingDir())}
                   disabled={browseLoading()}
                   style={{
@@ -902,6 +904,7 @@ export default function SessionList() {
                   <For each={browseDirs()}>
                     {(dir) => (
                       <button
+                        data-testid={`working-dir-option-${dir.name === ".." ? "parent" : dir.name}`}
                         onClick={() => {
                           if (dir.name === "..") {
                             browseDirectory(dir.path);

--- a/frontend/src/components/togaf/DependencyGraph/DependencyGraph.tsx
+++ b/frontend/src/components/togaf/DependencyGraph/DependencyGraph.tsx
@@ -238,7 +238,7 @@ export const DependencyGraph: Component = () => {
                 const color = STATUS_COLORS[node.status] ?? "var(--overlay0)";
                 return (
                   <g
-                    data-testid={`dep-node-${node.id}`}
+                    data-testid={`dependency-node-${node.id}`}
                     style={{ cursor: "pointer", transition: "opacity 200ms ease" }}
                     opacity={isHighlighted(node.id) ? 1 : 0.2}
                     onClick={() => {
@@ -279,6 +279,7 @@ export const DependencyGraph: Component = () => {
 
                     {/* Node rect */}
                     <rect
+                      data-testid={`dep-node-${node.id}`}
                       x={node.x - node.width / 2}
                       y={node.y - node.height / 2}
                       width={node.width}

--- a/frontend/src/components/togaf/RiskMatrix/RiskMatrix.tsx
+++ b/frontend/src/components/togaf/RiskMatrix/RiskMatrix.tsx
@@ -75,6 +75,7 @@ export const RiskMatrix: Component = () => {
                     return (
                       <div
                         class={`risk-cell ${risks().length > 0 ? cellClass : ""}`}
+                        data-testid={`risk-cell-${likelihood}-${severity}`}
                         style={{
                           opacity: risks().length > 0 ? "1" : "0.3",
                           background: risks().length === 0 ? "var(--surface0)" : undefined,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2086,7 +2086,94 @@ async fn api_get_plan_json(
     }
 }
 
-/// POST /api/plans/{name}/edits — Write plan-edits.json for the session to pick up.
+fn append_incoming_edit_values(target: &mut Vec<serde_json::Value>, value: serde_json::Value) {
+    match value {
+        serde_json::Value::Array(items) => target.extend(items),
+        serde_json::Value::Null => {}
+        other => target.push(other),
+    }
+}
+
+fn append_existing_edit_values(
+    target: &mut Vec<serde_json::Value>,
+    value: serde_json::Value,
+) -> Result<(), String> {
+    match value {
+        serde_json::Value::Array(items) => {
+            target.extend(items);
+            Ok(())
+        }
+        serde_json::Value::Null => Ok(()),
+        _ => Err("existing plan-edits.json `edits` field must be an array".to_string()),
+    }
+}
+
+fn merge_plan_edit_payloads(
+    existing: Option<serde_json::Value>,
+    incoming: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let mut base = serde_json::Map::new();
+    let mut edits = Vec::new();
+
+    match existing {
+        Some(serde_json::Value::Object(mut object)) => {
+            if let Some(existing_edits) = object.remove("edits") {
+                append_existing_edit_values(&mut edits, existing_edits)?;
+            }
+            base = object;
+        }
+        Some(serde_json::Value::Array(items)) => edits.extend(items),
+        Some(serde_json::Value::Null) | None => {}
+        Some(_) => {
+            return Err("existing plan-edits.json must be a JSON object or array".to_string());
+        }
+    }
+
+    match incoming {
+        serde_json::Value::Object(mut object) => {
+            if let Some(incoming_edits) = object.remove("edits") {
+                append_incoming_edit_values(&mut edits, incoming_edits);
+                for (key, value) in object {
+                    base.insert(key, value);
+                }
+            } else {
+                edits.push(serde_json::Value::Object(object));
+            }
+        }
+        serde_json::Value::Array(items) => edits.extend(items),
+        serde_json::Value::Null => {}
+        other => edits.push(other),
+    }
+
+    base.insert("edits".to_string(), serde_json::Value::Array(edits));
+    Ok(serde_json::Value::Object(base))
+}
+
+fn atomic_json_tmp_path(path: &std::path::Path) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("plan-edits.json");
+    path.with_file_name(format!("{file_name}.tmp-{}-{stamp}", std::process::id()))
+}
+
+async fn write_json_atomic(path: &std::path::Path, json: &str) -> std::io::Result<()> {
+    let tmp_path = atomic_json_tmp_path(path);
+    tokio::fs::write(&tmp_path, json).await?;
+    match tokio::fs::rename(&tmp_path, path).await {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            Err(err)
+        }
+    }
+}
+
+/// POST /api/plans/{name}/edits — Append plan-edits.json for the session to pick up.
 async fn api_post_plan_edits(
     State(state): State<AppState>,
     Path(name): Path<String>,
@@ -2110,13 +2197,50 @@ async fn api_post_plan_edits(
         return axum::Json(serde_json::json!({"error": "failed to create directory"}));
     }
 
-    match serde_json::to_string_pretty(&edits) {
+    let existing = match tokio::fs::read_to_string(&edits_path).await {
+        Ok(raw) => match serde_json::from_str::<serde_json::Value>(&raw) {
+            Ok(value) => Some(value),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    plan = %name,
+                    "refusing to overwrite invalid plan-edits.json"
+                );
+                return axum::Json(serde_json::json!({"error": "existing edits invalid"}));
+            }
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => {
+            tracing::warn!(error = %e, plan = %name, "failed to read plan-edits.json");
+            return axum::Json(serde_json::json!({"error": "read failed"}));
+        }
+    };
+
+    let merged_edits = match merge_plan_edit_payloads(existing, edits) {
+        Ok(value) => value,
+        Err(e) => {
+            tracing::warn!(error = %e, plan = %name, "failed to merge plan-edits payload");
+            return axum::Json(serde_json::json!({"error": e}));
+        }
+    };
+    let edit_count = merged_edits
+        .get("edits")
+        .and_then(|value| value.as_array())
+        .map(|items| items.len())
+        .unwrap_or_default();
+
+    match serde_json::to_string_pretty(&merged_edits) {
         Ok(json_str) => {
-            if let Err(e) = tokio::fs::write(&edits_path, &json_str).await {
+            if let Err(e) = write_json_atomic(&edits_path, &json_str).await {
                 tracing::warn!(error = %e, plan = %name, "failed to write plan-edits.json");
                 return axum::Json(serde_json::json!({"error": "write failed"}));
             }
-            info!(plan = %name, path = %edits_path.display(), "wrote plan-edits.json");
+            info!(
+                plan = %name,
+                path = %edits_path.display(),
+                edits = edit_count,
+                "wrote plan-edits.json"
+            );
 
             // Publish plan update via WebTransport bus so connected clients
             // receive the change instantly without polling.
@@ -2128,9 +2252,84 @@ async fn api_post_plan_edits(
                 info!(plan = %name, "published plan update via WebTransport");
             }
 
-            axum::Json(serde_json::json!({"ok": true, "plan": name}))
+            axum::Json(serde_json::json!({"ok": true, "plan": name, "edits": edit_count}))
         }
         Err(e) => axum::Json(serde_json::json!({"error": e.to_string()})),
+    }
+}
+
+#[cfg(test)]
+mod plan_edits_tests {
+    use serde_json::json;
+
+    use super::{merge_plan_edit_payloads, write_json_atomic};
+
+    #[test]
+    fn plan_edits_merge_appends_incoming_edits_without_dropping_existing() {
+        let existing = json!({
+            "version": 1,
+            "edits": [
+                {"type": "gate_status", "id": 1, "status": "pending"}
+            ]
+        });
+        let incoming = json!({
+            "source": "ui",
+            "edits": [
+                {"type": "gate_status", "id": 1, "status": "pass"}
+            ]
+        });
+
+        let merged = merge_plan_edit_payloads(Some(existing), incoming).unwrap();
+        assert_eq!(merged["version"], json!(1));
+        assert_eq!(merged["source"], json!("ui"));
+        assert_eq!(merged["edits"].as_array().unwrap().len(), 2);
+        assert_eq!(merged["edits"][0]["status"], json!("pending"));
+        assert_eq!(merged["edits"][1]["status"], json!("pass"));
+    }
+
+    #[test]
+    fn plan_edits_merge_accepts_legacy_array_and_single_edit_payloads() {
+        let existing = json!([
+            {"type": "wp_status", "id": "wp-1", "status": "todo"}
+        ]);
+        let incoming = json!({"type": "section_status", "id": "b-1", "status": "done"});
+
+        let merged = merge_plan_edit_payloads(Some(existing), incoming).unwrap();
+        assert_eq!(merged["edits"].as_array().unwrap().len(), 2);
+        assert_eq!(merged["edits"][0]["type"], json!("wp_status"));
+        assert_eq!(merged["edits"][1]["type"], json!("section_status"));
+    }
+
+    #[test]
+    fn plan_edits_merge_rejects_invalid_existing_edit_shape() {
+        let existing = json!({"edits": "not-an-array"});
+        let incoming = json!({"edits": []});
+
+        assert!(merge_plan_edit_payloads(Some(existing), incoming).is_err());
+    }
+
+    #[tokio::test]
+    async fn plan_edits_atomic_write_replaces_target_and_removes_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plan-edits.json");
+        tokio::fs::write(&path, r#"{"edits":[{"id":1}]}"#)
+            .await
+            .unwrap();
+
+        write_json_atomic(&path, r#"{"edits":[{"id":2}]}"#)
+            .await
+            .unwrap();
+
+        let raw = tokio::fs::read_to_string(&path).await.unwrap();
+        assert_eq!(raw, r#"{"edits":[{"id":2}]}"#);
+
+        let mut entries = tokio::fs::read_dir(dir.path()).await.unwrap();
+        let mut file_count = 0;
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            file_count += 1;
+            assert_eq!(entry.file_name().to_string_lossy(), "plan-edits.json");
+        }
+        assert_eq!(file_count, 1);
     }
 }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2876,18 +2876,18 @@ async fn api_create_managed_session(
                             let plan_json = plan_dir.join("plan.json");
                             // Match only the explicit plan directory, not the first unrelated
                             // plan that happens to contain an IMPL-PLAN.md.
-                            if plan_json.exists() {
-                                if plan_dir_matches_working_dir(
+                            if plan_json.exists()
+                                && plan_dir_matches_working_dir(
                                     &name,
                                     &plan_dir,
                                     &impl_plan,
                                     &working_dir,
-                                ) {
-                                    let mut mapping = state.session_plan_mapping.write().await;
-                                    mapping.insert(sid, name.clone());
-                                    info!(session = %sid, plan = %name, "auto-bound session to plan");
-                                    break;
-                                }
+                                )
+                            {
+                                let mut mapping = state.session_plan_mapping.write().await;
+                                mapping.insert(sid, name.clone());
+                                info!(session = %sid, plan = %name, "auto-bound session to plan");
+                                break;
                             }
                         }
                     }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path as FsPath, PathBuf};
 use std::sync::Arc;
 
 use axum::Router;
@@ -105,6 +105,42 @@ fn plan_for_encoded_session_path(
     session_plan_mapping.get(managed_id).cloned()
 }
 
+fn plan_dir_matches_working_dir(
+    plan_name: &str,
+    plan_dir: &FsPath,
+    impl_plan: &FsPath,
+    working_dir: &FsPath,
+) -> bool {
+    let working_dir_name = working_dir
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_default();
+    if plan_name == working_dir_name {
+        return true;
+    }
+
+    let working_dir_canonical = std::fs::canonicalize(working_dir).ok();
+    if let Some(working_dir_canonical) = working_dir_canonical.as_deref() {
+        if std::fs::canonicalize(plan_dir)
+            .map(|path| path == working_dir_canonical)
+            .unwrap_or(false)
+        {
+            return true;
+        }
+
+        if std::fs::canonicalize(impl_plan)
+            .ok()
+            .and_then(|path| path.parent().map(FsPath::to_path_buf))
+            .map(|parent| parent == working_dir_canonical)
+            .unwrap_or(false)
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
 fn build_managed_session_persist_entries(
     managed_session_paths: &HashMap<String, Uuid>,
     session_plan_mapping: &HashMap<Uuid, String>,
@@ -143,7 +179,8 @@ mod managed_session_persistence_tests {
 
     use super::{
         PersistedManagedSession, build_managed_session_persist_entries,
-        plan_for_encoded_session_path, restore_managed_session_entries,
+        plan_dir_matches_working_dir, plan_for_encoded_session_path,
+        restore_managed_session_entries,
     };
 
     #[test]
@@ -215,6 +252,50 @@ mod managed_session_persistence_tests {
         assert_eq!(entries[0].plan, "alpha-plan");
         assert_eq!(entries[1].path, "-work-zeta");
         assert_eq!(entries[1].plan, "");
+    }
+
+    #[test]
+    fn plan_dir_match_rejects_unrelated_impl_plan_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plan_discovery = tmp.path().join("plan-discovery");
+        let issue_plan = tmp.path().join("issue-94-verification");
+        std::fs::create_dir_all(&plan_discovery).unwrap();
+        std::fs::create_dir_all(&issue_plan).unwrap();
+        std::fs::write(plan_discovery.join("IMPL-PLAN.md"), "# unrelated").unwrap();
+        std::fs::write(issue_plan.join("plan.json"), "{}").unwrap();
+
+        assert!(!plan_dir_matches_working_dir(
+            "plan-discovery",
+            &plan_discovery,
+            &plan_discovery.join("IMPL-PLAN.md"),
+            &issue_plan,
+        ));
+        assert!(plan_dir_matches_working_dir(
+            "issue-94-verification",
+            &issue_plan,
+            &issue_plan.join("IMPL-PLAN.md"),
+            &issue_plan,
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn plan_dir_match_accepts_impl_plan_symlink_target_parent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let working_dir = tmp.path().join("project");
+        let plan_dir = tmp.path().join("external-plan");
+        std::fs::create_dir_all(&working_dir).unwrap();
+        std::fs::create_dir_all(&plan_dir).unwrap();
+        let working_impl = working_dir.join("IMPL-PLAN.md");
+        std::fs::write(&working_impl, "# linked").unwrap();
+
+        std::os::unix::fs::symlink(&working_impl, plan_dir.join("IMPL-PLAN.md")).unwrap();
+        assert!(plan_dir_matches_working_dir(
+            "external-plan",
+            &plan_dir,
+            &plan_dir.join("IMPL-PLAN.md"),
+            &working_dir,
+        ));
     }
 }
 
@@ -2789,23 +2870,18 @@ async fn api_create_managed_session(
                             && ft.is_dir()
                         {
                             let name = entry.file_name().to_string_lossy().to_string();
-                            let impl_plan = entry.path().join("IMPL-PLAN.md");
-                            let plan_json = entry.path().join("plan.json");
-                            // Check if this plan dir has an IMPL-PLAN.md and the session
-                            // working dir contains an IMPL-PLAN.md too
+                            let plan_dir = entry.path();
+                            let impl_plan = plan_dir.join("IMPL-PLAN.md");
+                            let plan_json = plan_dir.join("plan.json");
+                            // Match only the explicit plan directory, not the first unrelated
+                            // plan that happens to contain an IMPL-PLAN.md.
                             if plan_json.exists() {
-                                let _session_impl =
-                                    PathBuf::from(&body.working_dir).join("IMPL-PLAN.md");
-                                // Match by: plan dir has symlink to session dir, or
-                                // session dir name matches plan name
-                                let working_dir_name = PathBuf::from(&body.working_dir)
-                                    .file_name()
-                                    .map(|n| n.to_string_lossy().to_string())
-                                    .unwrap_or_default();
-                                if impl_plan.exists()
-                                    || name == working_dir_name
-                                    || name.contains(&working_dir_name)
-                                {
+                                if plan_dir_matches_working_dir(
+                                    &name,
+                                    &plan_dir,
+                                    &impl_plan,
+                                    &working_dir,
+                                ) {
                                     let mut mapping = state.session_plan_mapping.write().await;
                                     mapping.insert(sid, name.clone());
                                     info!(session = %sid, plan = %name, "auto-bound session to plan");

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -63,6 +63,161 @@ struct AppState {
     session_plan_mapping: Arc<RwLock<HashMap<Uuid, String>>>,
 }
 
+const MANAGED_SESSIONS_FILE: &str = "/data/noaide/managed-sessions.json";
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+struct PersistedManagedSession {
+    session_id: Uuid,
+    #[serde(default)]
+    path: String,
+    #[serde(default)]
+    plan: String,
+}
+
+fn restore_managed_session_entries(
+    entries: &[PersistedManagedSession],
+    managed_session_paths: &mut HashMap<String, Uuid>,
+    session_plan_mapping: &mut HashMap<Uuid, String>,
+) -> (usize, usize) {
+    let mut restored_paths = 0usize;
+    let mut restored_plans = 0usize;
+
+    for entry in entries {
+        if !entry.path.is_empty() {
+            managed_session_paths.insert(entry.path.clone(), entry.session_id);
+            restored_paths += 1;
+        }
+        if !entry.plan.is_empty() {
+            session_plan_mapping.insert(entry.session_id, entry.plan.clone());
+            restored_plans += 1;
+        }
+    }
+
+    (restored_paths, restored_plans)
+}
+
+fn plan_for_encoded_session_path(
+    encoded_path: &str,
+    managed_session_paths: &HashMap<String, Uuid>,
+    session_plan_mapping: &HashMap<Uuid, String>,
+) -> Option<String> {
+    let managed_id = managed_session_paths.get(encoded_path)?;
+    session_plan_mapping.get(managed_id).cloned()
+}
+
+fn build_managed_session_persist_entries(
+    managed_session_paths: &HashMap<String, Uuid>,
+    session_plan_mapping: &HashMap<Uuid, String>,
+) -> Vec<PersistedManagedSession> {
+    let mut entries: Vec<PersistedManagedSession> = managed_session_paths
+        .iter()
+        .map(|(path, session_id)| PersistedManagedSession {
+            session_id: *session_id,
+            path: path.clone(),
+            plan: session_plan_mapping
+                .get(session_id)
+                .cloned()
+                .unwrap_or_default(),
+        })
+        .collect();
+    entries.sort_by(|a, b| a.path.cmp(&b.path).then(a.session_id.cmp(&b.session_id)));
+    entries
+}
+
+async fn persist_managed_session_entries(
+    entries: &[PersistedManagedSession],
+) -> std::io::Result<()> {
+    let path = std::path::Path::new(MANAGED_SESSIONS_FILE);
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let json = serde_json::to_string_pretty(entries).map_err(std::io::Error::other)?;
+    write_json_atomic(path, &(json + "\n")).await
+}
+
+#[cfg(test)]
+mod managed_session_persistence_tests {
+    use std::collections::HashMap;
+
+    use uuid::Uuid;
+
+    use super::{
+        PersistedManagedSession, build_managed_session_persist_entries,
+        plan_for_encoded_session_path, restore_managed_session_entries,
+    };
+
+    #[test]
+    fn managed_session_restore_loads_paths_and_plans() {
+        let managed_id = Uuid::parse_str("11111111-1111-4111-8111-111111111111").unwrap();
+        let jsonl_id = Uuid::parse_str("22222222-2222-4222-8222-222222222222").unwrap();
+        let entries = vec![
+            PersistedManagedSession {
+                session_id: managed_id,
+                path: "-work-noaide".to_string(),
+                plan: "portfolio-website".to_string(),
+            },
+            PersistedManagedSession {
+                session_id: jsonl_id,
+                path: String::new(),
+                plan: "ignored-pathless-plan".to_string(),
+            },
+        ];
+
+        let mut paths = HashMap::new();
+        let mut plans = HashMap::new();
+        let (path_count, plan_count) =
+            restore_managed_session_entries(&entries, &mut paths, &mut plans);
+
+        assert_eq!(path_count, 1);
+        assert_eq!(plan_count, 2);
+        assert_eq!(paths.get("-work-noaide"), Some(&managed_id));
+        assert_eq!(
+            plans.get(&managed_id).map(String::as_str),
+            Some("portfolio-website")
+        );
+        assert_eq!(
+            plans.get(&jsonl_id).map(String::as_str),
+            Some("ignored-pathless-plan")
+        );
+    }
+
+    #[test]
+    fn managed_session_plan_lookup_reassociates_jsonl_encoded_path() {
+        let managed_id = Uuid::parse_str("33333333-3333-4333-8333-333333333333").unwrap();
+        let mut paths = HashMap::new();
+        paths.insert("-work-noaide".to_string(), managed_id);
+        let mut plans = HashMap::new();
+        plans.insert(managed_id, "portfolio-website".to_string());
+
+        assert_eq!(
+            plan_for_encoded_session_path("-work-noaide", &paths, &plans).as_deref(),
+            Some("portfolio-website")
+        );
+        assert_eq!(
+            plan_for_encoded_session_path("-work-other", &paths, &plans),
+            None
+        );
+    }
+
+    #[test]
+    fn managed_session_persist_entries_are_stable_and_include_plan() {
+        let first = Uuid::parse_str("44444444-4444-4444-8444-444444444444").unwrap();
+        let second = Uuid::parse_str("55555555-5555-4555-8555-555555555555").unwrap();
+        let mut paths = HashMap::new();
+        paths.insert("-work-zeta".to_string(), second);
+        paths.insert("-work-alpha".to_string(), first);
+        let mut plans = HashMap::new();
+        plans.insert(first, "alpha-plan".to_string());
+
+        let entries = build_managed_session_persist_entries(&paths, &plans);
+
+        assert_eq!(entries[0].path, "-work-alpha");
+        assert_eq!(entries[0].plan, "alpha-plan");
+        assert_eq!(entries[1].path, "-work-zeta");
+        assert_eq!(entries[1].plan, "");
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
@@ -181,26 +336,19 @@ async fn main() -> anyhow::Result<()> {
     if !persist_dir.exists() {
         let _ = tokio::fs::create_dir_all(persist_dir).await;
     }
-    if let Ok(data) = tokio::fs::read_to_string("/data/noaide/managed-sessions.json").await
-        && let Ok(entries) = serde_json::from_str::<Vec<serde_json::Value>>(&data)
+    if let Ok(data) = tokio::fs::read_to_string(MANAGED_SESSIONS_FILE).await
+        && let Ok(entries) = serde_json::from_str::<Vec<PersistedManagedSession>>(&data)
     {
         let mut mapping = session_plan_mapping.write().await;
-        for entry in &entries {
-            if let (Some(sid), Some(plan)) = (
-                entry["session_id"]
-                    .as_str()
-                    .and_then(|s| Uuid::parse_str(s).ok()),
-                entry["plan"].as_str(),
-            ) && !plan.is_empty()
-            {
-                mapping.insert(sid, plan.to_string());
-            }
-        }
+        let mut paths = managed_session_paths.write().await;
+        let (restored_paths, restored_plans) =
+            restore_managed_session_entries(&entries, &mut paths, &mut mapping);
         info!(
-            restored = mapping.len(),
-            "restored session→plan mappings from previous run"
+            restored_paths,
+            restored_plans, "restored managed session mappings from previous run"
         );
         drop(mapping);
+        drop(paths);
     }
 
     match noaide_server::proxy::keys::load_from_disk(&proxy_state.key_store) {
@@ -542,7 +690,21 @@ async fn main() -> anyhow::Result<()> {
         all_sessions.extend(sessions);
     }
 
+    let restored_plan_by_path: HashMap<String, String> = {
+        let managed_paths = managed_session_paths.read().await;
+        let plan_mapping = session_plan_mapping.read().await;
+        managed_paths
+            .iter()
+            .filter_map(|(encoded_path, managed_id)| {
+                plan_mapping
+                    .get(managed_id)
+                    .map(|plan| (encoded_path.clone(), plan.clone()))
+            })
+            .collect()
+    };
+
     // Phase 2: Register sessions in ECS (fast — no parsing yet)
+    let mut restored_jsonl_plan_bindings: Vec<(Uuid, String)> = Vec::new();
     {
         let mut world = ecs.write().await;
         let mut paths = session_paths.write().await;
@@ -557,6 +719,16 @@ async fn main() -> anyhow::Result<()> {
             cli_types.insert(session_id, session_info.cli_type);
             if session_info.message_count_hint > 0 {
                 hints.insert(session_id, session_info.message_count_hint);
+            }
+            if let Some(encoded_dir) = extract_encoded_project_dir(&session_info.jsonl_path)
+                && let Some(plan) = restored_plan_by_path.get(&encoded_dir)
+            {
+                restored_jsonl_plan_bindings.push((session_id, plan.clone()));
+                info!(
+                    session = %session_id,
+                    plan = %plan,
+                    "restored plan binding for discovered JSONL session"
+                );
             }
             world.spawn_session(SessionComponent {
                 id: session_id,
@@ -576,6 +748,12 @@ async fn main() -> anyhow::Result<()> {
             sessions = world.session_count(),
             "sessions registered (parsing in background)"
         );
+    }
+    if !restored_jsonl_plan_bindings.is_empty() {
+        let mut plan_mapping = session_plan_mapping.write().await;
+        for (session_id, plan) in restored_jsonl_plan_bindings {
+            plan_mapping.entry(session_id).or_insert(plan);
+        }
     }
 
     // Phase 2b: Register project directory watches for FILE_CHANGES (WP-10)
@@ -2649,12 +2827,13 @@ async fn api_create_managed_session(
             {
                 let mapping = state.session_plan_mapping.read().await;
                 let msp = state.managed_session_paths.read().await;
-                let persist: Vec<serde_json::Value> = msp.iter().map(|(path, id)| {
-                    let plan = mapping.get(id).cloned().unwrap_or_default();
-                    serde_json::json!({"session_id": id.to_string(), "path": path, "plan": plan})
-                }).collect();
-                if let Ok(json) = serde_json::to_string_pretty(&persist) {
-                    let _ = tokio::fs::write("/data/noaide/managed-sessions.json", json).await;
+                let persist = build_managed_session_persist_entries(&msp, &mapping);
+                if let Err(e) = persist_managed_session_entries(&persist).await {
+                    warn!(
+                        error = %e,
+                        session = %sid,
+                        "failed to persist managed session mappings"
+                    );
                 }
             }
             (

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -96,6 +96,7 @@ fn restore_managed_session_entries(
     (restored_paths, restored_plans)
 }
 
+#[cfg(test)]
 fn plan_for_encoded_session_path(
     encoded_path: &str,
     managed_session_paths: &HashMap<String, Uuid>,

--- a/server/src/session/managed.rs
+++ b/server/src/session/managed.rs
@@ -673,6 +673,41 @@ mod tests {
         );
     }
 
+    #[test]
+    fn claude_exec_argv_omits_auto_approve_flag_by_default() {
+        let (_, args) = build_exec_argv("claude", false, None).unwrap();
+        let rendered: Vec<String> = args
+            .iter()
+            .map(|arg| arg.to_str().unwrap().to_string())
+            .collect();
+
+        assert_eq!(rendered, vec!["claude".to_string()]);
+    }
+
+    #[test]
+    fn auto_approve_flag_is_claude_only() {
+        let (_, codex_args) = build_exec_argv(
+            "codex",
+            true,
+            Some("http://localhost:4434/s/test-session/backend-api/"),
+        )
+        .unwrap();
+        let codex_rendered: Vec<String> = codex_args
+            .iter()
+            .map(|arg| arg.to_str().unwrap().to_string())
+            .collect();
+
+        assert!(!codex_rendered.contains(&"--dangerously-skip-permissions".to_string()));
+
+        let (_, gemini_args) = build_exec_argv("gemini", true, None).unwrap();
+        let gemini_rendered: Vec<String> = gemini_args
+            .iter()
+            .map(|arg| arg.to_str().unwrap().to_string())
+            .collect();
+
+        assert_eq!(gemini_rendered, vec!["gemini".to_string()]);
+    }
+
     #[tokio::test]
     async fn spawn_echo_session() {
         // Spawn a simple echo command instead of claude (which may not be installed)


### PR DESCRIPTION
## Summary

This PR completes the issue #94 verification branch and keeps the implementation changes visible on GitHub before closing the issue.

## Changes

- Preserve managed-session plan associations across restarts and avoid binding a new managed session to an unrelated `IMPL-PLAN.md` plan.
- Add UI affordances and test IDs needed for managed session creation, plan selection, TOGAF views, gate/checklist edits, and Kanban verification.
- Expose the Claude auto-approve option in the managed-session create flow and pass it through as `auto_approve`.

## Verification

- `git diff --check`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `cargo remote -c -- fmt --all -- --check`
- `cargo remote -c -- build -p noaide-server`
- `cargo remote -c -- test`
- Full UI verification through Playwright against `https://localhost:9999/noaide/` and backend health/API checks on `http://localhost:8080`.

Related: #94