### PR TITLE
fix(e2e): use baseURL for smoke and mobile tests

### DIFF
--- a/frontend/e2e/mobile.test.ts
+++ b/frontend/e2e/mobile.test.ts
@@ -8,7 +8,7 @@ test.describe("mobile layout (375x812)", () => {
   test.use({ viewport: { width: 375, height: 812 } });
 
   test.beforeEach(async ({ page }) => {
-    await page.goto("https://localhost:9999/", { waitUntil: "networkidle" });
+    await page.goto("/", { waitUntil: "networkidle" });
     const welcome = page.getByTestId("welcome-dismiss");
     if (await welcome.isVisible({ timeout: 2000 }).catch(() => false)) {
       await welcome.click();

--- a/frontend/e2e/smoke.test.ts
+++ b/frontend/e2e/smoke.test.ts
@@ -6,12 +6,9 @@
  */
 import { test, expect } from "@playwright/test";
 
-const BASE = "https://localhost:9999";
-
 test.describe("noaide smoke tests", () => {
   test.beforeEach(async ({ page }) => {
-    // Ignore TLS cert errors for self-signed dev cert
-    await page.goto(BASE, { waitUntil: "networkidle" });
+    await page.goto("/", { waitUntil: "networkidle" });
     // Dismiss welcome screen if shown
     const welcome = page.getByTestId("welcome-dismiss");
     if (await welcome.isVisible({ timeout: 2000 }).catch(() => false)) {


### PR DESCRIPTION
## Summary
- Tests hardcoded `https://localhost:9999` but `playwright.config.ts` launches preview server on `localhost:4173` via `webServer.command`
- All 16 smoke/mobile tests failed on main with `ERR_CONNECTION_REFUSED`
- Switch to relative `page.goto("/")` so tests use `baseURL` from config

## Test plan
- [ ] CI: `E2E Smoke Tests` job succeeds
- [ ] CI: CI Gate stays green
- [ ] Locally: `cd frontend && pnpm run e2e` passes (when run against the preview server)

Fixes the E2E regression that appeared on main after #129.