### PR TITLE
fix(ci): build and start backend for E2E smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: e2e-smoke
+
       - uses: pnpm/action-setup@v4
         with:
           version: 10
@@ -444,7 +450,21 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: frontend/pnpm-lock.yaml
 
-      - name: Install dependencies
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
+      - name: Build WASM modules
+        run: |
+          for mod in jsonl-parser markdown compress; do
+            wasm-pack build wasm/$mod --target web --out-dir ../../frontend/src/wasm/$mod
+          done
+
+      - name: Build backend server
+        run: cargo build --release --bin noaide-server
+
+      - name: Install frontend dependencies
         run: cd frontend && pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers
@@ -453,8 +473,41 @@ jobs:
       - name: Build frontend
         run: cd frontend && pnpm run build
 
+      - name: Start backend server
+        run: |
+          mkdir -p /tmp/noaide-ci/data /tmp/noaide-ci/plans
+          NOAIDE_DB_PATH=/tmp/noaide-ci/data/ide.db \
+          NOAIDE_PLAN_DIR=/tmp/noaide-ci/plans \
+          NOAIDE_LOG_LEVEL=info \
+          nohup ./target/release/noaide-server > /tmp/noaide-ci/server.log 2>&1 &
+          echo "server_pid=$!" >> "$GITHUB_ENV"
+          # Wait for HTTP API (port 8080) to be ready
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/health > /dev/null 2>&1; then
+              echo "Backend ready after ${i}s"; break
+            fi
+            sleep 1
+          done
+          curl -sf http://localhost:8080/health || (echo "Backend not responding:"; cat /tmp/noaide-ci/server.log; exit 1)
+
       - name: Run E2E smoke tests
         run: cd frontend && pnpm run e2e
+
+      - name: Backend log on failure
+        if: failure()
+        run: |
+          echo "=== Backend log ==="
+          cat /tmp/noaide-ci/server.log || true
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-${{ github.run_number }}
+          path: |
+            frontend/playwright-report/
+            frontend/test-results/
+          retention-days: 7
 
   # ──────────────────────────────────────────────────────────────
   # CI Gate: Single required check that always runs.

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,15 +5,16 @@ export default defineConfig({
   timeout: 30_000,
   retries: 1,
   use: {
-    baseURL: "http://localhost:4173",
+    baseURL: "http://localhost:4173/noaide/",
     headless: true,
     screenshot: "only-on-failure",
+    ignoreHTTPSErrors: true,
   },
   webServer: {
     command: "pnpm preview",
     port: 4173,
     reuseExistingServer: !process.env.CI,
-    timeout: 15_000,
+    timeout: 30_000,
   },
   projects: [
     {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -50,6 +50,21 @@ export default defineConfig({
       },
     },
   },
+  preview: {
+    port: 4173,
+    strictPort: true,
+    headers: {
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
+    },
+    proxy: {
+      "/api": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+        ws: true,
+      },
+    },
+  },
   build: {
     target: "esnext",
     rollupOptions: {


### PR DESCRIPTION
## Summary
- \`e2e-smoke\` only served the frontend preview build, so any test that touched \`/api/*\` failed with ECONNREFUSED once Playwright rendered a page that fetches backend data
- Build + start \`noaide-server\` in the workflow (mirrors \`nightly.yml\`), add a matching \`preview\` proxy to \`vite.config.ts\`, fix the baseURL to point at \`/noaide/\`
- Surface the backend log and the Playwright report as artifacts when the job fails

## Test plan
- [ ] CI \`E2E Smoke Tests\` job succeeds on main
- [ ] CI Gate stays green
- [ ] Failure artifacts are uploaded when the job fails (exercised indirectly by passing runs not uploading anything)