### PR TITLE
test(e2e): seed fixtures for smoke test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,11 +473,19 @@ jobs:
       - name: Build frontend
         run: cd frontend && pnpm run build
 
+      - name: Seed E2E fixtures
+        run: |
+          mkdir -p /tmp/noaide-ci/data
+          cp -r frontend/e2e/fixtures/claude-home /tmp/noaide-ci/claude-home
+          cp -r frontend/e2e/fixtures/plans /tmp/noaide-ci/plans
+          echo "Seeded sessions:"; find /tmp/noaide-ci/claude-home -type f
+          echo "Seeded plans:"; find /tmp/noaide-ci/plans -name plan.json
+
       - name: Start backend server
         run: |
-          mkdir -p /tmp/noaide-ci/data /tmp/noaide-ci/plans
           NOAIDE_DB_PATH=/tmp/noaide-ci/data/ide.db \
           NOAIDE_PLAN_DIR=/tmp/noaide-ci/plans \
+          NOAIDE_WATCH_PATHS=/tmp/noaide-ci/claude-home \
           NOAIDE_LOG_LEVEL=info \
           nohup ./target/release/noaide-server > /tmp/noaide-ci/server.log 2>&1 &
           echo "server_pid=$!" >> "$GITHUB_ENV"
@@ -489,6 +497,14 @@ jobs:
             sleep 1
           done
           curl -sf http://localhost:8080/health || (echo "Backend not responding:"; cat /tmp/noaide-ci/server.log; exit 1)
+          # Give discovery scanner time to index the seeded fixtures
+          for i in $(seq 1 15); do
+            count=$(curl -sf http://localhost:8080/api/sessions | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo 0)
+            if [ "$count" -ge 3 ]; then
+              echo "Discovery indexed $count sessions after ${i}s"; break
+            fi
+            sleep 1
+          done
 
       - name: Run E2E smoke tests
         run: cd frontend && pnpm run e2e

--- a/frontend/e2e/fixtures/claude-home/projects/-demo/a1b2c3d4-e5f6-7890-abcd-ef1234567890.jsonl
+++ b/frontend/e2e/fixtures/claude-home/projects/-demo/a1b2c3d4-e5f6-7890-abcd-ef1234567890.jsonl
@@ -1,0 +1,2 @@
+{"type":"user","message":{"role":"user","content":"hello from claude demo session"},"uuid":"msg-1","parentUuid":null,"sessionId":"a1b2c3d4-e5f6-7890-abcd-ef1234567890","timestamp":"2026-04-24T00:00:00.000Z"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]},"uuid":"msg-2","parentUuid":"msg-1","sessionId":"a1b2c3d4-e5f6-7890-abcd-ef1234567890","timestamp":"2026-04-24T00:00:01.000Z"}

--- a/frontend/e2e/fixtures/claude-home/sessions/2026/04/24/rollout-1704067200-b2c3d4e5-f6a7-8901-bcde-f12345678901.jsonl
+++ b/frontend/e2e/fixtures/claude-home/sessions/2026/04/24/rollout-1704067200-b2c3d4e5-f6a7-8901-bcde-f12345678901.jsonl
@@ -1,0 +1,2 @@
+{"type":"event_msg","payload":{"type":"session_configured","session_id":"b2c3d4e5-f6a7-8901-bcde-f12345678901","model":"gpt-5"},"timestamp":"2026-04-24T00:00:00.000Z"}
+{"type":"event_msg","payload":{"type":"agent_message_delta","delta":"hi from codex"},"timestamp":"2026-04-24T00:00:01.000Z"}

--- a/frontend/e2e/fixtures/claude-home/tmp/abcdefg/chats/session-1704067200-c3d4e5f6-a7b8-9012-cdef-123456789012.json
+++ b/frontend/e2e/fixtures/claude-home/tmp/abcdefg/chats/session-1704067200-c3d4e5f6-a7b8-9012-cdef-123456789012.json
@@ -1,0 +1,15 @@
+{
+  "sessionId": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+  "startTime": "2026-04-24T00:00:00.000Z",
+  "lastUpdated": "2026-04-24T00:00:02.000Z",
+  "messages": [
+    {
+      "role": "user",
+      "parts": [{ "text": "hello from gemini" }]
+    },
+    {
+      "role": "model",
+      "parts": [{ "text": "hi" }]
+    }
+  ]
+}

--- a/frontend/e2e/fixtures/plans/demo/plan.json
+++ b/frontend/e2e/fixtures/plans/demo/plan.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "togaf-plan/1.0",
+  "meta": {
+    "title": "Demo plan for E2E smoke tests",
+    "version": "v1.0",
+    "tailoring": "M",
+    "scope": "scope:full",
+    "status": "In Progress",
+    "confidence": 80,
+    "date": "2026-04-24",
+    "wip_limit": 3,
+    "critical_path": "WP-1 -> WP-2 -> WP-3",
+    "footer_stats": "3 WPs | 0 Risks | 0 ADRs",
+    "adm_iteration": 1,
+    "last_updated": "2026-04-24T00:00:00Z",
+    "github_repo": "silentspike/noaide"
+  },
+  "gates": {
+    "0": "pass",
+    "1": "pass",
+    "2": "pass",
+    "3": "pass",
+    "4": "pass"
+  },
+  "sections": {},
+  "work_packages": [
+    {
+      "id": "WP-1",
+      "title": "Foundation",
+      "status": "done",
+      "size": "M",
+      "sprint": 1,
+      "dependencies": [],
+      "assignee": "claude",
+      "scope_files": [],
+      "gate_required": false,
+      "verify_checks": [],
+      "complexity": "Simple"
+    },
+    {
+      "id": "WP-2",
+      "title": "Implementation",
+      "status": "in_progress",
+      "size": "L",
+      "sprint": 1,
+      "dependencies": ["WP-1"],
+      "assignee": "claude",
+      "scope_files": [],
+      "gate_required": false,
+      "verify_checks": [],
+      "complexity": "Medium"
+    },
+    {
+      "id": "WP-3",
+      "title": "Verification",
+      "status": "backlog",
+      "size": "S",
+      "sprint": 2,
+      "dependencies": ["WP-2"],
+      "assignee": "codex",
+      "scope_files": [],
+      "gate_required": false,
+      "verify_checks": [],
+      "complexity": "Simple"
+    }
+  ],
+  "risks": [],
+  "adrs": [],
+  "requirements": [],
+  "dependency_graph": {
+    "nodes": [
+      { "id": "WP-1" },
+      { "id": "WP-2" },
+      { "id": "WP-3" }
+    ],
+    "edges": [
+      { "from": "WP-1", "to": "WP-2" },
+      { "from": "WP-2", "to": "WP-3" }
+    ]
+  },
+  "sprints": [
+    { "id": "S1", "name": "Sprint 1", "work_packages": ["WP-1", "WP-2"] },
+    { "id": "S2", "name": "Sprint 2", "work_packages": ["WP-3"] }
+  ]
+}


### PR DESCRIPTION
## Summary
- Smoke tests expected a populated UI (session cards, group headers, plan with kanban/graph). A fresh backend has none of that, so data-dependent tests timed out even though the UI itself rendered fine
- Seed minimal fixtures (1 Claude, 1 Codex, 1 Gemini session + 1 togaf plan) into the CI watch and plan dirs before starting the server; poll \`/api/sessions\` until the discovery scanner has indexed them

## Test plan
- [ ] CI on main: \`E2E Smoke Tests\` grün
- [ ] Fixture files render as expected when the preview + backend are running locally (not exercised here)