### PR TITLE
docs(contributing): document commit-discipline single-concern principle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,17 @@ pnpm audit
 wasm-pack build wasm/jsonl-parser --target web
 ```
 
+## Commit Discipline
+
+Commits follow Conventional Commits **and** the single-concern principle: one
+logical change per commit, reviewable on its own, with a clear imperative
+subject and a body that explains the why when it is not obvious from the diff.
+
+A few multi-concern commits from the early WP-1 / WP-2 bootstrap phase are kept
+in the history for fidelity — they document the actual ramp-up velocity and
+scaffolding, not current practice. All new commits are expected to be
+single-concern.
+
 ## Commit Messages
 
 We use [Conventional Commits](https://www.conventionalcommits.org/).


### PR DESCRIPTION
## Summary
- Add a `Commit Discipline` section to CONTRIBUTING.md stating the single-concern rule for new commits and acknowledging the bootstrap-phase multi-concern commits in the history
- Supports the hygiene sprint's self-awareness about earlier WP-1 / WP-2 ramp-up commits

## Test plan
- [ ] CI green (docs-only)
- [ ] Section renders correctly on GitHub