### PR TITLE
docs(certs): add privacy note and verification steps

### DIFF
--- a/certs/README.md
+++ b/certs/README.md
@@ -2,6 +2,22 @@
 
 Local TLS certificates for WebTransport (HTTP/3 QUIC) development.
 
+## Privacy Note
+
+All `.pem` files in this directory are **gitignored**. Each developer
+generates their own local certificates. Certificates are never committed.
+
+`mkcert` embeds the generator's `OU=<user>@<hostname>` into the certificate
+subject. Since the `.pem` files stay local, this has no public exposure —
+but be aware if you share your Vite dev server, browser DevTools, or
+curl output with others, the certificate subject will contain your
+username and machine hostname.
+
+If you prefer a neutral subject, generate certificates on a machine with a
+neutral user/hostname (e.g. inside a container), or use raw `openssl` /
+`cfssl` to produce a custom `O=noaide development certificate` subject
+without user/host identifiers.
+
 ## Generate
 
 ```bash
@@ -9,7 +25,8 @@ Local TLS certificates for WebTransport (HTTP/3 QUIC) development.
 mkcert -install
 
 # Generate certificates
-mkcert -cert-file certs/cert.pem -key-file certs/key.pem localhost 127.0.0.1 ::1
+mkcert -cert-file certs/cert.pem -key-file certs/key.pem \
+  noaide.local localhost 127.0.0.1 ::1
 ```
 
 ## Files
@@ -18,11 +35,20 @@ mkcert -cert-file certs/cert.pem -key-file certs/key.pem localhost 127.0.0.1 ::1
 |------|---------|------------|
 | `cert.pem` | TLS certificate | Yes |
 | `key.pem` | TLS private key | Yes |
-
-Certificate files are gitignored. Each developer must generate their own.
+| `rootCA.pem` | Local CA copy (from `mkcert -CAROOT`) | Yes |
 
 ## Why mkcert?
 
 WebTransport requires valid TLS certificates. `mkcert` creates a local CA
 trusted by the system and browser, avoiding certificate warnings during
-development. The CA is stored in the system trust store (not in this directory).
+development. The CA is stored in the system trust store (not in this
+directory).
+
+## Verification
+
+After generation, verify the certificate has no stale hostnames:
+
+```bash
+openssl x509 -in certs/cert.pem -noout -subject
+openssl x509 -in certs/cert.pem -noout -ext subjectAltName
+```


### PR DESCRIPTION
## Summary
- Document that mkcert embeds `OU=<user>@<hostname>` into cert subjects
- Note that `.pem` files are gitignored, so this is a local-only concern
- Add verification commands (`openssl x509 -noout -subject` + SAN check) so users can spot stale hostnames

## Context
Part of the public-readiness hygiene sprint (Phase 6). Certificates were regenerated locally — the subject no longer contains the old `Proxmoxx.fritz.box` hostname. README now documents the pattern for future contributors.

## Test plan
- [x] `openssl x509 -in certs/cert.pem -noout -subject` shows a clean subject (no stale hostname)
- [x] README renders correctly on github.com
- [ ] CI Gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)