### PR TITLE
docs: add docs/ tree with 4 initial reference pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,20 @@ configured base-URL override when the supervisor enables the proxy, and
 [AGENTS.md §4](AGENTS.md#4-agent-contract) for per-agent integration
 paths.
 
+## Documentation
+
+| Document | Scope |
+|----------|-------|
+| [AGENTS.md](AGENTS.md) | Contract between supervisor, agent, and noaide |
+| [docs/architecture.md](docs/architecture.md) | Components, data flows, wire format, threading model |
+| [docs/api.md](docs/api.md) | HTTP endpoint reference for the control plane |
+| [docs/agent-operating-model.md](docs/agent-operating-model.md) | How noaide watches agents (JSONL, PTY, filesystem) |
+| [docs/supervision-boundaries.md](docs/supervision-boundaries.md) | Control surfaces and what noaide does vs. does not enforce |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Branch flow, commit discipline, PR checklist |
+| [SECURITY.md](SECURITY.md) | Security controls in place and on the roadmap |
+| [TESTING.md](TESTING.md) | Test gate matrix |
+| [llms.txt](llms.txt) | 11 ADRs behind the architecture decisions |
+
 ## Security
 
 API keys (`sk-ant-*`, `Bearer *`) are automatically redacted in all logs and UI via regex. The API proxy only forwards to `api.anthropic.com` (whitelist). All transport uses TLS 1.3 via QUIC. See [SECURITY.md](SECURITY.md) for vulnerability reporting.

--- a/docs/agent-operating-model.md
+++ b/docs/agent-operating-model.md
@@ -1,0 +1,98 @@
+# Agent Operating Model
+
+> This document expands [AGENTS.md §1](../AGENTS.md#1-operating-model).
+> Read AGENTS.md first — it is the contract. This document is the
+> implementation-level explanation.
+
+## Observer, not runner
+
+noaide never invokes an agent. The agent is a separate process that
+the supervisor (or the supervisor's tooling) started before or after
+noaide. noaide's role is to watch.
+
+This distinction matters because it shapes the failure model:
+
+- If noaide crashes, the agent keeps running. On restart, noaide
+  reconstructs state from the JSONL files.
+- If the agent crashes, noaide sees its PTY close (managed) or its
+  tmux pane go idle (observed). Session state in the UI goes to
+  `Ended`. The JSONL on disk is the durable record.
+- noaide cannot repair an agent that has locked up. The supervisor
+  can kill it via `/api/sessions/{id}/close` (managed) or manually
+  (observed).
+
+## What is observed
+
+For each agent, noaide derives the full UI state from three inputs:
+
+1. **JSONL on disk** — one line per conversation turn. Claude Code
+   writes to
+   `~/.claude/projects/{encoded-project-path}/{session-uuid}.jsonl`.
+   Gemini CLI writes JSON files under
+   `~/.gemini/tmp/{project-hash}/chats/session-*.json`. Codex writes
+   to `~/.codex/sessions/YYYY/MM/DD/rollout-*-{uuid}.jsonl`.
+
+2. **PTY output** (managed sessions only) — the raw terminal buffer.
+   noaide uses this to animate the Breathing Orb (IDLE / THINKING /
+   STREAMING / TOOL_USE / ERROR) because JSONL writes lag behind the
+   visible cursor.
+
+3. **Filesystem events** — eBPF ringbuf from the kernel, attributed by
+   PID. When the agent's PID writes to a tracked file, the UI marks
+   that change as "agent". When your editor's PID writes, it marks it
+   "you".
+
+Everything else — session cards, token budgets, git diffs, network
+records — is derived from these three inputs.
+
+## Pluggable format adapters
+
+The parser treats JSONL variants as plugins. Three adapters ship
+today (Claude, Gemini, Codex) under `server/src/parser/`. Adding a
+new agent requires:
+
+- An adapter that maps raw JSONL lines to the internal `Message` type
+- A discovery glob that finds its session files on disk
+- A base URL convention for the proxy if the agent supports one
+
+Core UI components (chat panel, editor, network tab) do not know
+which agent produced a message — they render the normalized shape.
+
+## State materialization
+
+The ECS world is the hot in-memory state. Every message, session,
+file, task, and agent entity lives there. Systems update components
+when events arrive on the bus.
+
+The database is a persistent cache on top of the ECS world:
+
+- Recent messages have FTS5 indexes so Cmd+F is fast
+- Sessions, stats, and cost breakdowns cache there
+- It can be deleted at any time — the next startup rebuilds it from
+  the JSONL files
+
+This design makes recovery simple: if noaide behaves oddly, delete
+`$NOAIDE_DB_PATH` and restart.
+
+## The Breathing Orb state machine
+
+| State | PTY signal | JSONL ground truth | UI |
+|-------|-----------|--------------------|----|
+| IDLE | no output for >2 s | `stop_reason: "end_turn"` | Lavender, 2 s slow pulse |
+| THINKING | braille spinner | `type: "thinking"` | Mauve, 0.5 s fast pulse |
+| STREAMING | block cursor + text | `stop_reason: null` | Blue, 1 s breathing |
+| TOOL_USE | tool-pattern regex | `type: "tool_use"` | Peach, 1.5 s rotate |
+| ERROR | stderr or exit != 0 | `is_error: true` | Red, 0.3 s rapid pulse |
+
+The PTY column is an optimistic signal — it transitions the orb fast
+so the UI feels reactive. The JSONL column is the source of truth —
+the orb snaps to the JSONL state when the write lands, resolving any
+disagreement. This is why the transitions sometimes skip a frame:
+the PTY was ahead, the JSONL caught up, the reconcile collapsed the
+difference.
+
+## Related docs
+
+- [AGENTS.md](../AGENTS.md) — the supervisor contract
+- [architecture.md](architecture.md) — components behind this document
+- [supervision-boundaries.md](supervision-boundaries.md) — the control surfaces

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,122 @@
+# HTTP API Reference
+
+noaide's backend exposes an HTTP/1.1 API on port `8080` (configurable
+via `NOAIDE_HTTP_PORT`) for control-plane operations. The streaming
+data plane is WebTransport on port `4433`; this document only covers
+the HTTP surface.
+
+All endpoints are implemented in
+[`server/src/main.rs`](../server/src/main.rs) unless noted otherwise.
+Paths may evolve while the project is in pre-alpha.
+
+## Conventions
+
+- JSON bodies unless stated otherwise
+- `Content-Type: application/json` on POST/PUT
+- UUIDs for session IDs, kebab-case for other identifiers
+- CORS is same-origin; the dev proxy on :9999 routes `/api/*` to :8080
+- Errors return a JSON body with `{"error": "...", "detail": "..."}`
+
+## Server metadata
+
+| Method | Path | Response |
+|--------|------|----------|
+| GET | `/health` | `200 OK` plaintext when the server is ready |
+| GET | `/api/server-info` | Build info: version, git sha, enabled feature flags |
+
+## Sessions
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/sessions` | List all discovered sessions (observed + managed) |
+| POST | `/api/sessions/managed` | Spawn a managed session with a specific agent + command |
+| GET | `/api/sessions/{id}` | Full session detail (metadata, agent type, paths) |
+| GET | `/api/sessions/{id}/messages` | Parsed JSONL messages with pagination |
+| GET | `/api/sessions/{id}/stats` | Token counts, model breakdown, duration |
+| GET | `/api/sessions/{id}/files` | Files touched during this session |
+| POST | `/api/sessions/{id}/input` | Send raw bytes to the PTY / tmux pane |
+| POST | `/api/sessions/{id}/send` | Send a user message (includes newline handling) |
+| POST | `/api/sessions/{id}/append` | Append to the JSONL without driving input |
+| POST | `/api/sessions/{id}/images` | Attach images to the next message |
+| POST | `/api/sessions/{id}/close` | Stop a managed session |
+
+The `/input` and `/send` split is important: `send` implements the
+per-agent handshake (Gemini splits text and newline by 30 ms because
+Ink TUIs otherwise eat the newline), while `input` is a raw pipe.
+
+## Filesystem
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/files?path=…` | Read a file (text, returned as `{content, sha}`) |
+| GET | `/api/browse?path=…` | Directory listing for the File tree |
+
+## Git
+
+All git routes operate on the project the session is inside.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/git/branches` | Local + remote branches, current HEAD |
+| GET | `/api/git/status` | Working-tree status (staged + unstaged) |
+| GET | `/api/git/log` | Paginated commit log |
+| GET | `/api/git/blame` | Per-line blame for a file |
+| GET | `/api/git/diff-hunks` | Hunk-level diff of the working tree |
+| GET | `/api/git/prs` | Open PRs (uses `gh` CLI if available) |
+| POST | `/api/git/stage` | Stage a file |
+| POST | `/api/git/stage-hunk` | Stage a specific hunk |
+| POST | `/api/git/unstage` | Unstage a file |
+| POST | `/api/git/commit` | Commit the staged set |
+| POST | `/api/git/checkout` | Switch branch |
+
+## Plans (TOGAF)
+
+The plan subsystem backs the TOGAF panel.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/plans` | List available plans under `/work/plan/` |
+| GET | `/api/plans/{name}/plan.json` | The raw plan JSON |
+| POST | `/api/plans/{name}/edits` | Append an edit to `plan-edits.json` |
+
+## Proxy (API recorder)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/proxy/requests?session_id=…` | Recorded request/response pairs |
+| GET | `/api/proxy/audit` | Full audit log (rotated) |
+| GET | `/api/proxy/audit/export` | Download the audit as NDJSON |
+| GET/POST | `/api/proxy/keys` | Manage redaction keys |
+| GET | `/api/proxy/keys/status` | Status of currently installed keys |
+| GET/POST | `/api/proxy/presets` | Preset configurations for proxy behaviour |
+
+The forwarding side lives at `/s/{uuid}/...` and is handled in
+[`server/src/proxy/`](../server/src/proxy/); it is not an `/api/*`
+route.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/ca.pem` / `/api/ca.crt` | Local mkcert root CA for proxy trust |
+
+## Teams
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/teams` | List team names |
+| GET | `/api/teams/{name}/tasks` | Task board for a team |
+| GET | `/api/teams/{name}/topology` | Force-directed graph data |
+
+## WebSocket
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| WS | `/api/ws/transcribe` | Voice-to-text streaming (proxies to the Whisper sidecar on `:8082`) |
+
+The Whisper sidecar (`server/whisper/server.py`) is a separate Python
+process. The Rust server forwards PCM frames from the browser and
+streams back partial + final transcripts.
+
+## Related docs
+
+- [architecture.md](architecture.md) — how HTTP fits into the wider system
+- [../AGENTS.md](../AGENTS.md) — supervisor contract these routes serve

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,187 @@
+# Architecture
+
+noaide is a Rust backend that watches AI coding agents on disk and
+streams their state to a SolidJS browser UI over WebTransport.
+
+The high-level picture is in the [README](../README.md#architecture).
+This document fills in the components, their responsibilities, and how
+data moves between them.
+
+## Components
+
+### File watcher (`server/src/watcher/`)
+
+Observes the agent's home directory (`~/.claude/`, `~/.gemini/`,
+`~/.codex/`) for file creations, writes, and deletions. eBPF
+(`ebpf.rs`) is the primary backend because it carries the writing PID,
+which the UI uses to distinguish "you wrote this" from "the agent wrote
+this". An inotify fallback (`fallback.rs`) activates when eBPF is not
+available (missing capabilities, unsupported kernel).
+
+### JSONL parser (`server/src/parser/`)
+
+Streaming parser for agent conversation logs. Maintains per-session
+byte offsets so each new line triggers incremental work: parse → emit
+event. Handles three variants (Claude Code, Gemini CLI, Codex) via
+pluggable format adapters. JSONL is the source of truth; the DB and
+ECS state are regeneratable caches.
+
+### Session discovery (`server/src/discovery/`)
+
+Scans agent home directories at startup and on filesystem change to
+build the initial session list. Provides the mapping from on-disk
+paths to session IDs that other components reference.
+
+### Session manager (`server/src/session/`)
+
+Two modes:
+
+- **Managed** (`managed.rs`) — noaide owns the PTY, spawns the agent as
+  a child process, and can kill or restart it.
+- **Observed** (`observed.rs`) — the agent runs anywhere. noaide
+  attaches input using `tmux send-keys` to the agent's existing pane.
+
+Both modes surface the same session API to the rest of the server.
+
+### ECS state engine (`server/src/ecs/`)
+
+In-memory state built on [`hecs`](https://docs.rs/hecs). Components
+for sessions, messages, files, tasks, and agents live in
+struct-of-arrays storage (cache-friendly iteration). Systems are
+functions that run per event — they read components, compute
+derivations, and write the results back. This is where the hot loop
+lives.
+
+### Limbo database (`server/src/db/`)
+
+Async SQLite via [Limbo](https://github.com/tursodatabase/limbo). Used
+as an index and cache for fast queries and full-text search (FTS5
+feature-gated with `index_experimental`). Schema in `schema.rs`,
+queries in `queries.rs`. If the DB is lost, it can be rebuilt from the
+JSONL files.
+
+### Event bus (`server/src/bus/`)
+
+[Zenoh](https://zenoh.io/) with shared-memory transport for
+inter-component messaging. Targets ~1 µs publish latency within a
+process. Every message on the bus is wrapped in an `EventEnvelope`
+(see `types.rs` in the ECS module) carrying a Lamport clock, source,
+session ID, and deduplication key.
+
+### Transport (`server/src/transport/`)
+
+WebTransport (HTTP/3 QUIC) server implemented over
+[`wtransport`](https://docs.rs/wtransport). Multiplexes streams over
+a single TLS 1.3 connection. Adaptive quality tier:
+
+| Tier | RTT bucket | Target rate |
+|------|-----------|-------------|
+| 120 Hz | < 50 ms | hot-path frames each vsync |
+| 30 Hz  | 50–150 ms | throttled hot path |
+| 10 Hz  | > 150 ms | heavy throttle, batch cold path |
+
+Hot-path frames use FlatBuffers for zero-copy decoding in the browser.
+Cold-path frames (file tree, git state, session list) use MessagePack.
+Both paths are Zstd-compressed.
+
+### API proxy (`server/src/proxy/`)
+
+Per-session reverse proxy at `/s/{session}/...`. Intercepts API calls
+the agent makes (Anthropic, Gemini, Codex upstreams) and records them
+so the Network tab can show the request/response pair. Secrets are
+redacted on the way through. The proxy can also hold requests in
+"manual mode" — nothing forwards until the supervisor approves.
+
+### Git integration (`server/src/git/`)
+
+Wraps [`git2`](https://docs.rs/git2) to expose branches, status, diff,
+stage/unstage, commit, blame, and log to the browser. Called directly
+by HTTP handlers, not on the bus.
+
+### Teams (`server/src/teams/`)
+
+Derives the agent hierarchy (parent/child sub-agents) from JSONL
+`agentId`/`parentUuid` fields and serves it to the Teams panel for the
+topology graph and swimlane views.
+
+## Data flow
+
+Three flows dominate the request/response pattern.
+
+### 1. File change → browser
+
+```
+inode write ──▸ eBPF program (bpf/noaide.bpf.c)
+               │  PID, path, event type
+               ▼
+           watcher::ebpf::RingBuf consumer
+               ▼
+           Event { source: Watcher, ... }  published on zenoh topic
+               ▼
+           ECS system handler — updates File component
+               ▼
+           transport adapts to RTT tier — serializes (FlatBuffers + Zstd)
+               ▼
+           browser WebTransport client — decodes — SolidJS signal update
+```
+
+Target end-to-end latency: < 50 ms p99 (a design goal; see
+[issue #142](https://github.com/silentspike/noaide/issues/142)).
+
+### 2. Browser input → agent
+
+```
+browser typed input ──▸ fetch POST /api/sessions/{id}/input
+                       ▼
+                   Axum handler → session_manager.send_input()
+                       ▼
+                   Managed PTY write  OR  tmux send-keys
+                       ▼
+                   Agent process reads on stdin
+                       ▼
+                   Agent writes to JSONL + stdout
+                       ▼
+                   (loop back through flow 1)
+```
+
+### 3. Agent API call → supervisor visibility
+
+```
+Agent process                noaide proxy                    upstream (e.g. api.anthropic.com)
+      │                            │                                  │
+      ├── POST /s/{uuid}/v1/... ─▶ │                                  │
+      │                            ├─ redact + record request         │
+      │                            ├─ gate (auto/manual) ────────────▶│
+      │                            │                                  │
+      │                            │◀────── streamed SSE response ────┤
+      │◀────── forwarded ──────────┤                                  │
+      │                            ├─ record response                 │
+      │                            ▼                                  │
+      │                       Network tab event on the bus
+```
+
+## Wire format
+
+- **Hot path**: FlatBuffers schema in
+  [`schemas/messages.fbs`](../schemas/messages.fbs). Decoded
+  zero-copy in the browser (`frontend/src/transport/codec.ts`).
+- **Cold path**: MessagePack frames carrying SessionList, FileTree,
+  GitState, TeamTopology.
+- **Compression**: Both paths are Zstd-framed. WASM decoder in
+  `wasm/compress/` lifts the payload on the browser side.
+
+## Threading and concurrency
+
+The server runs on a multi-threaded `tokio` runtime (workers = CPU
+count). Hot components (watcher, parser, ECS update, transport
+serializer) are pinned to bounded channels so backpressure is
+explicit — when the transport is slow, the channel fills and older
+`file.change` events drop oldest-first. `message.new` is a never-drop
+channel because losing a message is worse than latency.
+
+## Related docs
+
+- [README — Architecture diagram](../README.md#architecture)
+- [AGENTS.md](../AGENTS.md) — supervisor contract
+- [llms.txt](../llms.txt) — the 11 ADRs behind these choices
+- [api.md](api.md) — HTTP endpoint reference

--- a/docs/supervision-boundaries.md
+++ b/docs/supervision-boundaries.md
@@ -1,0 +1,145 @@
+# Supervision Boundaries
+
+> This document expands [AGENTS.md §2](../AGENTS.md#2-supervision-boundaries).
+> Read AGENTS.md first — it is the contract. This document explains
+> each control surface in more detail and shows what noaide does and
+> does not enforce.
+
+## Who controls what
+
+The supervisor is the human using the UI. The agent is a separate
+process. noaide stands between them and mediates specific surfaces:
+
+| Surface | Supervisor control | Agent control | Enforcement |
+|---------|--------------------|----------------|-------------|
+| Session lifecycle | Start, stop, kill, restart | Exit on its own | Managed mode: PTY + child-process API |
+| Keyboard / text input | Send input events | Consume input | PTY write (managed), tmux send-keys (observed) |
+| Tool approval | Hold / approve / deny | Request a tool | UI gate + proxy hold (where wired) |
+| API proxy | Auto vs. manual mode, drop, replay | Send HTTP | Reverse proxy middleware |
+| File-edit locks | Hold concurrent edits in OT buffer | Edit via tool-call | 3-way merge after agent finishes |
+
+## Session lifecycle
+
+### Managed
+
+A managed session is a child process under noaide's PTY. The server
+owns its stdin/stdout/stderr and its exit.
+
+Lifecycle API:
+
+- `POST /api/sessions/managed` — spawn
+- `POST /api/sessions/{id}/close` — send SIGTERM, then SIGKILL after 5 s
+
+noaide persists the session metadata so that the session list
+survives restarts, but the process itself does not — if the server
+dies, a managed session dies with it.
+
+### Observed
+
+An observed session is any agent running in a tmux pane that matches
+noaide's discovery filter. noaide attaches read-only to the JSONL
+and, optionally, writes input via `tmux send-keys`.
+
+There is no "kill" for observed sessions. The supervisor closes the
+pane themselves.
+
+## Input channels
+
+Two routes:
+
+- `/api/sessions/{id}/input` — raw bytes. Useful for sending
+  signals, arrow keys, control characters. The server writes exactly
+  what it receives.
+- `/api/sessions/{id}/send` — a "user message" abstraction. This
+  handles the per-agent submit handshake. Gemini's Ink TUI, for
+  instance, collapses `text\r` sent in one write into a newline
+  character; the send route splits text and carriage return with a
+  30 ms delay so the TUI treats the `\r` as submit.
+
+Both routes go to the same `SessionManager.send_input()` call — the
+difference is the pre-processing layer on top.
+
+## Tool approval and the proxy gate
+
+noaide does not sit between the agent and its tool execution (shell
+commands, file writes, etc.). The agent runs those directly on the
+host.
+
+noaide does sit between the agent and its LLM provider. The proxy
+operates in one of two modes:
+
+- **auto** — requests stream through as the agent sends them. Every
+  request is recorded for later inspection but nothing is blocked.
+- **manual** — noaide holds each request, surfaces it in the UI, and
+  waits for the supervisor to click Forward or Drop. Responses flow
+  through the same gate.
+
+Manual mode is the closest noaide has to tool approval: because the
+tool-use envelope is returned by the LLM, the supervisor sees the
+planned tool call before the agent does and can drop the response to
+prevent it.
+
+## API proxy guarantees
+
+The proxy is a whitelist. Only these upstreams forward:
+
+- `api.anthropic.com`
+- `cloudcode-pa.googleapis.com`
+- `chatgpt.com`
+
+Anything else gets `502 Bad Gateway`.
+
+Secret redaction runs before both the audit log and the UI
+representation. Patterns (regex):
+
+- `sk-ant-[A-Za-z0-9_-]+`
+- `Bearer [A-Za-z0-9_.~+/=-]+`
+- Claude session tokens and Anthropic billing IDs
+
+The audit log rotates and exports as NDJSON (`/api/proxy/audit/export`)
+so supervisors can take forensic copies.
+
+## File-edit locks
+
+When the agent starts editing a file (the UI detects this from the
+`tool_use` envelope for `Edit`, `Write`, or `MultiEdit` on Claude, or
+the equivalent for Gemini/Codex), noaide:
+
+1. Opens a yellow banner in the editor for that file.
+2. Holds supervisor edits in an Operational Transform buffer.
+3. Waits for the agent's matching `tool_result`.
+4. Runs a 3-way merge: agent's new content × your buffered edits ×
+   the common ancestor.
+5. On a clean merge, applies both automatically and clears the banner.
+6. On a conflict, opens CodeMirror's MergeView so the supervisor can
+   resolve manually.
+
+The OT buffer is in-memory only. If the browser refreshes mid-edit,
+the unmerged supervisor edits are lost.
+
+## What noaide does not enforce
+
+These are supervisor responsibilities, not noaide features:
+
+- **Sandboxing.** The agent runs with the supervisor's privileges.
+  noaide does not namespace, drop capabilities, or seccomp the child.
+- **Filesystem limits.** The agent can read and write anywhere the
+  supervisor can.
+- **Network controls beyond the proxy.** If the agent wants to make
+  a request outside the whitelist, noaide refuses to forward it — but
+  the agent can bypass noaide by calling the real URL directly from
+  its own HTTP client.
+- **Secrets hygiene.** noaide redacts known secret patterns from the
+  UI, but the underlying agent still sees them. A secret that the
+  agent has in memory is not "revoked" by the redaction.
+
+These boundaries are intentional. noaide is a transparency and
+supervision tool, not a sandbox.
+
+## Related docs
+
+- [AGENTS.md](../AGENTS.md) — the supervisor contract
+- [agent-operating-model.md](agent-operating-model.md) — how noaide watches the agent
+- [architecture.md](architecture.md) — components behind these surfaces
+- [api.md](api.md) — the HTTP routes this document references
+- [../SECURITY.md](../SECURITY.md) — security controls in place and on the roadmap


### PR DESCRIPTION
## Summary
Part of the public-readiness hygiene sprint (Phase 8d). Seeds \`docs/\` with four reference pages covering the questions new readers ask first.

- \`docs/architecture.md\` (187 lines) — components, data flows, wire format, threading
- \`docs/api.md\` (122 lines) — HTTP endpoint reference grouped by subject
- \`docs/agent-operating-model.md\` (98 lines) — expands \`AGENTS.md\` §1
- \`docs/supervision-boundaries.md\` (145 lines) — expands \`AGENTS.md\` §2

Adds a "Documentation" section to the README listing every top-level document.

## Related
- Expansion tracked in #146

## Test plan
- [x] All four pages render on github.com
- [x] Cross-links to \`AGENTS.md\` anchors resolve
- [ ] CI Gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)