### PR TITLE
fix(workflows): unblock release.yml flatc + nightly.yml gitleaks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -137,9 +137,10 @@ jobs:
         run: cd frontend && pnpm install --frozen-lockfile && pnpm audit --json > ../pnpm-audit-full.json || true
 
       - name: Gitleaks full scan
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          GITLEAKS_VERSION="8.24.3"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar xz
+          ./gitleaks detect --source=. --verbose --redact --log-opts="--all"
 
       - name: Upload security reports
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,13 @@ jobs:
             CHANGELOG.md > release_notes.md
 
       - name: Install FlatBuffers compiler
-        uses: taiki-e/install-action@v2
-        with:
-          tool: flatc
+        run: |
+          FLATC_VERSION="25.2.10"
+          curl -sSfL "https://github.com/google/flatbuffers/releases/download/v${FLATC_VERSION}/Linux.flatc.binary.g++-13.zip" -o /tmp/flatc.zip
+          unzip -o /tmp/flatc.zip -d /tmp flatc
+          chmod +x /tmp/flatc
+          sudo mv /tmp/flatc /usr/local/bin/
+          flatc --version
 
       - name: Generate FlatBuffers
         run: flatc --rust --ts -o generated/ schemas/messages.fbs


### PR DESCRIPTION
## Summary
Two workflow fixes, both unblocked by switching from broken action wrappers to direct binary installs.

### release.yml — flatc
The \`v0.1.0-alpha.1\` tag triggered the release workflow, which failed because \`taiki-e/install-action\` with \`tool: flatc\` resolves to the crates.io \`flatc\` package — that is a Rust library wrapper, not a binary, so \`cargo install\` aborts with \"there is nothing to install in flatc v0.2.2+23.5.26, because it has no binaries\".

Fix: download the prebuilt binary from the \`google/flatbuffers\` release page (pinned to v25.2.10), same as ci.yml.

### nightly.yml — gitleaks
\`gitleaks/gitleaks-action@v2\` now requires a paid \`GITLEAKS_LICENSE\` secret ([announcement](https://github.com/gitleaks/gitleaks-action#-announcement)), causing the nightly Extended Security Scan to fail with \"🛑 missing gitleaks license\". The \`gitleaks\` tool itself stays MIT-licensed.

Fix: install \`gitleaks\` directly from its GitHub release tarball (mirroring ci.yml), and add \`--log-opts=--all\` so the nightly variant scans the full history rather than only the working tree.

## Why this matters
- No release artefacts are produced for any tag without the flatc fix
- Nightly Extended Security Scan stays red purely on tooling licensing, masking real cargo-audit / pnpm-audit results

## Test plan
- [x] Same install pattern as ci.yml (already proven green)
- [ ] CI Gate green
- [ ] After merge: \`gh workflow run release.yml --ref v0.1.0-alpha.1\` produces release assets
- [ ] After merge: next nightly Extended Security Scan goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)