### PR TITLE
feat(ci): pnpm audit --audit-level=high in nightly (closes #141)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -168,8 +168,14 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: frontend/pnpm-lock.yaml
 
-      - name: Full pnpm audit
-        run: cd frontend && pnpm install --frozen-lockfile && pnpm audit --json > ../pnpm-audit-full.json || true
+      - name: Install frontend dependencies for audit
+        run: cd frontend && pnpm install --frozen-lockfile
+
+      - name: pnpm audit (full report — never fails)
+        run: cd frontend && pnpm audit --json > ../pnpm-audit-full.json || true
+
+      - name: pnpm audit (high+ severity — fails the job)
+        run: cd frontend && pnpm audit --audit-level=high
 
       - name: Gitleaks full scan
         run: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,7 @@ not yet in place are listed separately below.
 - GitHub Actions dependencies updated via Dependabot
 - CodeQL SAST scanning on every push/PR
 - `cargo audit` in the nightly CI workflow
+- `pnpm audit --audit-level=high` in the nightly CI workflow (fails on high+)
 - Secret scanning enabled on the repository
 - TLS 1.3 via QUIC/WebTransport for the dev server (self-signed local CA)
 - API key redaction (`sk-ant-*`, `Bearer *`) via regex in logs and UI
@@ -58,8 +59,6 @@ not yet in place are listed separately below.
 
 - [ ] Strict Content-Security-Policy on a production server
       (tracked in issue: "Enforce strict CSP on production server")
-- [ ] `npm audit` in the CI workflow (currently only `cargo audit` runs
-      nightly — tracked in issue: "Re-enable npm audit in nightly CI")
 - [ ] COOP/COEP as production HTTP response headers (currently only set
       by the Vite dev server — tracked in issue: "Enable COOP/COEP in
       production HTTP response headers")


### PR DESCRIPTION
Closes #141.

## Summary
The Extended Security Scan job in nightly produced a full \`pnpm-audit\` JSON artefact, but the step ended with \`|| true\` so the job never failed on actual advisories. Split into two steps:

1. \`pnpm audit --json > pnpm-audit-full.json || true\` — generates the artefact, never fails
2. \`pnpm audit --audit-level=high\` — fails the job on high or critical findings

This matches the CI \`security\` job (which uses \`pnpm audit --prod\`) and gives the nightly the same gate.

\`SECURITY.md\` moves "npm audit in CI" from Roadmap to In Place.

## AC Audit (will land in issue #141 on close)
| AC | Verification |
|----|--------------|
| AC-1 | \`pnpm audit --audit-level=high\` step in nightly.yml |
| AC-2 | Job fails on high+ — current pnpm-lock has 0 high (verified locally), test by checking new step exit code on real advisories when they appear |
| AC-3 | SECURITY.md In Place lists \`pnpm audit --audit-level=high\` |

## Test plan
- [x] CI Gate green (docs+workflow only)
- [ ] Next nightly run shows the new step running

🤖 Generated with [Claude Code](https://claude.com/claude-code)