### PR TITLE
feat(bench): criterion benchmarks for hot paths (closes #142)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -132,13 +132,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run benchmarks
-        run: cargo bench -- --output-format bencher | tee benchmark-results.txt
+        run: cargo bench -p noaide-server -- --output-format bencher | tee benchmark-results.txt
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-results-${{ github.run_number }}
-          path: benchmark-results.txt
+          path: |
+            benchmark-results.txt
+            target/criterion/**/report/index.html
+            target/criterion/**/base/estimates.json
+          if-no-files-found: warn
 
   extended-security:
     name: Extended Security Scan

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,7 +123,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -128,7 +134,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -469,6 +475,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +534,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -706,6 +745,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,6 +842,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -907,7 +985,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -952,7 +1030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1288,6 +1366,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1749,6 +1838,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2337,6 +2435,7 @@ dependencies = [
  "aya-log",
  "base64",
  "bytes",
+ "criterion",
  "dashmap",
  "flatbuffers",
  "futures-util",
@@ -2434,7 +2533,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2568,6 +2667,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
@@ -2834,6 +2939,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "pnet_base"
@@ -3133,6 +3266,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rcgen"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3367,7 +3520,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3435,7 +3588,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4025,7 +4178,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4130,6 +4283,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4920,7 +5083,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5488,7 +5651,7 @@ dependencies = [
  "flume",
  "futures",
  "git-version",
- "itertools",
+ "itertools 0.14.0",
  "json5",
  "lazy_static",
  "nonempty-collections",

--- a/README.md
+++ b/README.md
@@ -254,9 +254,15 @@ Architectural decisions are documented as [11 ADRs in llms.txt](llms.txt). Each 
 ## Performance — Design Goals
 
 These are the target numbers the architecture is designed around.
-A full benchmark suite is planned (`criterion` for Rust hot paths,
-Playwright traces for end-to-end latency) but not in place yet;
-treat the bars as design goals, not measured results.
+The `criterion` suite under `server/benches/` covers two hot paths
+(JSONL `parse_line` and ECS-cache `component_to_api_json`) and runs
+nightly — fetch the latest measurements from the **`benchmark-results-*`**
+artefact on the most recent
+[Nightly run](https://github.com/silentspike/noaide/actions/workflows/nightly.yml).
+End-to-end latency benchmarks (Playwright traces for the file event
+→ browser path, FPS at 1000+ messages) are still on the roadmap;
+treat any bar without a matching bench as a design goal, not a
+measurement.
 
 ```
 File event to browser       ████████████████████████████░░  < 50ms p99

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -58,3 +58,12 @@ togaf-parser = { path = "../crates/togaf-parser" }
 
 [dev-dependencies]
 tempfile = "3"
+criterion = { version = "0.7", features = ["html_reports"] }
+
+[[bench]]
+name = "jsonl_parser"
+harness = false
+
+[[bench]]
+name = "ecs_cache"
+harness = false

--- a/server/benches/ecs_cache.rs
+++ b/server/benches/ecs_cache.rs
@@ -1,0 +1,145 @@
+//! Benchmarks for the ECS cache → API JSON hot path.
+//!
+//! Closes part of #142. The "<5ms cached message fetch" design goal
+//! quoted in the README depends on this conversion being fast.
+//!
+//! Run with: `cargo bench -p noaide-server --bench ecs_cache`
+
+use std::hint::black_box;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use noaide_server::cache::component_to_api_json;
+use noaide_server::ecs::components::{MessageComponent, MessageRole, MessageType};
+use uuid::Uuid;
+
+fn make_text_message() -> MessageComponent {
+    MessageComponent {
+        id: Uuid::new_v4(),
+        session_id: Uuid::new_v4(),
+        role: MessageRole::Assistant,
+        content: "I'll fix the authentication bug. Let me read the file first \
+                  to understand the current state, then make targeted edits."
+            .to_string(),
+        content_blocks_json: None,
+        timestamp: 1714000000000,
+        tokens: Some(120),
+        hidden: false,
+        message_type: MessageType::Text,
+        model: Some("claude-sonnet-4-5-20250929".to_string()),
+        stop_reason: Some("end_turn".to_string()),
+        input_tokens: Some(1500),
+        output_tokens: Some(120),
+        cache_creation_input_tokens: Some(0),
+        cache_read_input_tokens: Some(12000),
+    }
+}
+
+fn make_tool_use_message() -> MessageComponent {
+    let blocks = serde_json::json!([
+        {
+            "type": "tool_use",
+            "id": "toolu_01",
+            "name": "Read",
+            "input": {"file_path": "/work/noaide/frontend/src/login.ts"}
+        }
+    ]);
+    MessageComponent {
+        id: Uuid::new_v4(),
+        session_id: Uuid::new_v4(),
+        role: MessageRole::Assistant,
+        content: String::new(),
+        content_blocks_json: Some(blocks.to_string()),
+        timestamp: 1714000001000,
+        tokens: Some(40),
+        hidden: false,
+        message_type: MessageType::ToolUse,
+        model: Some("claude-sonnet-4-5-20250929".to_string()),
+        stop_reason: Some("tool_use".to_string()),
+        input_tokens: Some(1620),
+        output_tokens: Some(40),
+        cache_creation_input_tokens: Some(0),
+        cache_read_input_tokens: Some(12120),
+    }
+}
+
+fn make_user_message() -> MessageComponent {
+    MessageComponent {
+        id: Uuid::new_v4(),
+        session_id: Uuid::new_v4(),
+        role: MessageRole::User,
+        content: "Help me fix the auth bug in login.ts".to_string(),
+        content_blocks_json: None,
+        timestamp: 1714000000000,
+        tokens: None,
+        hidden: false,
+        message_type: MessageType::Text,
+        model: None,
+        stop_reason: None,
+        input_tokens: None,
+        output_tokens: None,
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens: None,
+    }
+}
+
+fn bench_component_to_api_json(c: &mut Criterion) {
+    let mut group = c.benchmark_group("component_to_api_json");
+
+    let user = make_user_message();
+    let assistant = make_text_message();
+    let tool_use = make_tool_use_message();
+
+    group.bench_function("user_text", |b| {
+        b.iter(|| {
+            let json = component_to_api_json(black_box(&user));
+            black_box(json);
+        });
+    });
+    group.bench_function("assistant_text", |b| {
+        b.iter(|| {
+            let json = component_to_api_json(black_box(&assistant));
+            black_box(json);
+        });
+    });
+    group.bench_function("tool_use", |b| {
+        b.iter(|| {
+            let json = component_to_api_json(black_box(&tool_use));
+            black_box(json);
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_pagination_window(c: &mut Criterion) {
+    // Simulate the API endpoint that returns a 200-message page —
+    // the most common cache-fetch shape.
+    let messages: Vec<MessageComponent> = (0..200)
+        .map(|i| {
+            if i % 3 == 0 {
+                make_user_message()
+            } else if i % 3 == 1 {
+                make_text_message()
+            } else {
+                make_tool_use_message()
+            }
+        })
+        .collect();
+
+    let mut group = c.benchmark_group("pagination_window");
+    group.throughput(Throughput::Elements(messages.len() as u64));
+    group.bench_function("200_message_page", |b| {
+        b.iter(|| {
+            let out: Vec<serde_json::Value> = messages.iter().map(component_to_api_json).collect();
+            black_box(out);
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_component_to_api_json,
+    bench_pagination_window
+);
+criterion_main!(benches);

--- a/server/benches/jsonl_parser.rs
+++ b/server/benches/jsonl_parser.rs
@@ -1,0 +1,72 @@
+//! Benchmarks for the JSONL parser hot path.
+//!
+//! Closes part of #142. The parse rate quoted in the README as a
+//! design goal (>10k lines/s) is measured here.
+//!
+//! Run with: `cargo bench -p noaide-server --bench jsonl_parser`
+
+use std::hint::black_box;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use noaide_server::parser::parse_line;
+
+const REALISTIC_USER_MESSAGE: &str = r#"{"parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/work/noaide","sessionId":"abc-123","version":"1.0.0","gitBranch":"main","type":"user","message":{"role":"user","content":"Help me fix the auth bug in login.ts"},"uuid":"01H8XYZ","timestamp":"2026-04-26T08:00:00.000Z"}"#;
+
+const REALISTIC_ASSISTANT_MESSAGE: &str = r#"{"parentUuid":"01H8XYZ","isSidechain":false,"userType":"external","cwd":"/work/noaide","sessionId":"abc-123","version":"1.0.0","gitBranch":"main","type":"assistant","message":{"id":"msg_01","model":"claude-sonnet-4-5-20250929","role":"assistant","content":[{"type":"text","text":"I'll fix the authentication bug. Let me read the file first to understand the current state."}],"stop_reason":"end_turn","usage":{"input_tokens":1500,"cache_creation_input_tokens":0,"cache_read_input_tokens":12000,"output_tokens":120}},"uuid":"01H8AAA","timestamp":"2026-04-26T08:00:01.000Z"}"#;
+
+const REALISTIC_TOOL_USE_MESSAGE: &str = r#"{"parentUuid":"01H8AAA","isSidechain":false,"userType":"external","cwd":"/work/noaide","sessionId":"abc-123","version":"1.0.0","gitBranch":"main","type":"assistant","message":{"id":"msg_02","model":"claude-sonnet-4-5-20250929","role":"assistant","content":[{"type":"tool_use","id":"toolu_01","name":"Read","input":{"file_path":"/work/noaide/frontend/src/login.ts"}}],"stop_reason":"tool_use"},"uuid":"01H8BBB","timestamp":"2026-04-26T08:00:02.000Z"}"#;
+
+const REALISTIC_THINKING_MESSAGE: &str = r#"{"parentUuid":"01H8BBB","isSidechain":false,"userType":"external","cwd":"/work/noaide","sessionId":"abc-123","version":"1.0.0","gitBranch":"main","type":"assistant","message":{"id":"msg_03","model":"claude-sonnet-4-5-20250929","role":"assistant","content":[{"type":"thinking","thinking":"The user wants to fix auth. Let me trace through getToken first to understand the flow before making changes. I should read login.ts then check if there are tests that already exercise this path."}]},"uuid":"01H8CCC","timestamp":"2026-04-26T08:00:03.000Z"}"#;
+
+fn bench_parse_line(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parse_line");
+
+    // Throughput in bytes per iteration so the report includes MB/s.
+    let cases: &[(&str, &str)] = &[
+        ("user_message", REALISTIC_USER_MESSAGE),
+        ("assistant_message", REALISTIC_ASSISTANT_MESSAGE),
+        ("tool_use_message", REALISTIC_TOOL_USE_MESSAGE),
+        ("thinking_message", REALISTIC_THINKING_MESSAGE),
+    ];
+
+    for (label, line) in cases {
+        group.throughput(Throughput::Bytes(line.len() as u64));
+        group.bench_function(*label, |b| {
+            b.iter(|| {
+                let msg = parse_line(black_box(line)).expect("valid JSONL line");
+                black_box(msg);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_parse_line_mixed_workload(c: &mut Criterion) {
+    // Simulate a real session: user message, then a few assistant
+    // turns with tool use and thinking. This is closer to the cache
+    // warm path which calls parse_line for every line in a JSONL file.
+    let mixed: Vec<&str> = vec![
+        REALISTIC_USER_MESSAGE,
+        REALISTIC_ASSISTANT_MESSAGE,
+        REALISTIC_TOOL_USE_MESSAGE,
+        REALISTIC_THINKING_MESSAGE,
+        REALISTIC_ASSISTANT_MESSAGE,
+    ];
+    let total_bytes: u64 = mixed.iter().map(|s| s.len() as u64).sum();
+
+    let mut group = c.benchmark_group("parse_line_mixed");
+    group.throughput(Throughput::Bytes(total_bytes));
+    group.bench_function("five_line_session", |b| {
+        b.iter(|| {
+            for line in &mixed {
+                let m = parse_line(black_box(line)).expect("valid JSONL line");
+                black_box(m);
+            }
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_parse_line, bench_parse_line_mixed_workload);
+criterion_main!(benches);


### PR DESCRIPTION
Closes #142.

## Summary
Adds two criterion benchmarks for the hot paths the README quotes
as "Design Goals":

| File | Measures | README design-goal it backs |
|------|----------|------------------------------|
| \`server/benches/jsonl_parser.rs\` | \`parser::parse_line()\` against four realistic shapes (user, assistant text, tool_use, thinking) + a five-line mixed workload | "JSONL parse rate > 10k lines/s" |
| \`server/benches/ecs_cache.rs\` | \`cache::component_to_api_json()\` against three component variants + a 200-message pagination window | "<5 ms cached message fetch" |

\`server/Cargo.toml\` gets criterion 0.7 (with \`html_reports\`) as a dev-dep and two \`[[bench]]\` entries.

## Nightly integration

\`.github/workflows/nightly.yml\` already runs \`cargo bench\`. This PR scopes the invocation with \`-p noaide-server\` (the wasm crates have no benches) and expands the artefact upload to include the criterion HTML report and the bencher text summary.

## README update

The Performance section now says:

> The criterion suite under \`server/benches/\` covers two hot paths
> (JSONL parse_line and ECS-cache component_to_api_json) and runs
> nightly — fetch the latest measurements from the
> benchmark-results-* artefact on the most recent Nightly run.
> End-to-end latency benchmarks (Playwright traces …) are still on
> the roadmap; treat any bar without a matching bench as a design
> goal, not a measurement.

This is honest about what's now bench-covered vs still aspirational.

## AC checklist (will go into #142 on close)

| AC | Verification |
|----|--------------|
| AC-1 \`cargo bench\` runs the suite | \`cargo bench -p noaide-server --no-run\` compiles both benches; nightly invokes them |
| AC-2 Bench results uploaded as CI artefacts | nightly.yml uploads benchmark-results-* with bencher.txt + criterion HTML |
| AC-3 README "Design Goals" references the nightly artefact | grep README.md → "fetch the latest measurements from the benchmark-results-* artefact" |

## Test plan
- [x] \`cargo bench --no-run\` compiles both benches (verified locally)
- [ ] CI Gate green
- [ ] After merge: nightly artefact contains \`benchmark-results.txt\` with measurements

🤖 Generated with [Claude Code](https://claude.com/claude-code)