### PR TITLE
fix(devex): just dev / make dev pass --build to docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ help:
 	@echo "  demo                — build + seed fixtures + open browser"
 
 dev:
-	docker compose up
+	docker compose up --build
 
 dev-stop:
 	docker compose down

--- a/justfile
+++ b/justfile
@@ -14,8 +14,10 @@ default:
 
 # ── Local dev servers ─────────────────────────────────────────────
 # Bring up the whole thing in Docker (backend only; start `just dev-front` for HMR frontend).
+# `--build` forces the image to be built locally on first run; without it
+# `docker compose up` tries to pull `noaide:dev` from Docker Hub.
 dev:
-    docker compose up
+    docker compose up --build
 
 # Stop docker compose and remove containers.
 dev-stop:


### PR DESCRIPTION
## Bug
End-to-end validation found that \`just dev\` and \`make dev\` fail on a fresh checkout because \`docker compose up\` tries to pull \`noaide:dev\` from Docker Hub (we publish nowhere) instead of building locally:

\`\`\`
Image noaide:dev Pulling
Image noaide:dev Head \"https://registry-1.docker.io/.../noaide/manifests/dev\": connect: network is unreachable
\`\`\`

## Fix
Add \`--build\` to both \`dev\` recipes. The compose file keeps \`image: noaide:dev\` for tagging; the \`build:\` directive is already present. \`--build\` makes \`docker compose\` build before up.

## Test plan
- [x] \`just dev\` starts the build chain instead of pulling
- [ ] CI Gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)