### PR TITLE
docs: clarify onboarding gaps (no-image-yet, dev-vs-prod, voice-setup, first-launch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,24 @@ Verify: `grep CONFIG_BPF /boot/config-$(uname -r)`
 
 ## Quick Start
 
+There is no published Docker image yet — both paths below build
+from source. First build takes ≈ 4–10 min depending on the path
+and your machine.
+
+### What you also need (outside noaide)
+
+noaide watches an AI coding agent — it does not ship one. Install
+at least one of these and run it the way you normally would:
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+- [Gemini CLI](https://github.com/google-gemini/gemini-cli)
+- [OpenAI Codex](https://github.com/openai/codex)
+
+noaide reads the JSONL session files these tools write under
+`~/.claude/`, `~/.gemini/`, or `~/.codex/`.
+
+### Try it (development, hot-reload)
+
 ```bash
 # Clone
 git clone https://github.com/silentspike/noaide.git && cd noaide
@@ -317,8 +335,8 @@ git clone https://github.com/silentspike/noaide.git && cd noaide
 # First-run: generate local TLS certificates (needed for WebTransport)
 just certs          # or: make certs
 
-# Start the backend in Docker
-just dev            # or: make dev  (=> docker compose up)
+# Start the backend in Docker (builds the image on first run)
+just dev            # or: make dev  (=> docker compose up --build)
 
 # Start the frontend dev server in a second terminal (HMR)
 just dev-front      # or: make dev-front  (=> cd frontend && pnpm dev)
@@ -326,6 +344,36 @@ just dev-front      # or: make dev-front  (=> cd frontend && pnpm dev)
 # Open in browser
 #   http://localhost:9999/noaide/
 ```
+
+### Deploy it (production, single container)
+
+The dev workflow above is for hacking on noaide itself. To run a
+production-shaped deployment (single hardened container, prebuilt
+frontend bundle, BYO TLS), follow
+[docs/deployment-guide.md](docs/deployment-guide.md). Short version:
+
+```bash
+# Bring your own TLS chain into ./certs/{cert.pem,key.pem}
+# (LetsEncrypt, corporate CA, or mkcert for localhost — see deployment-guide)
+echo "NOAIDE_JWT_SECRET=$(openssl rand -hex 32)" > .env
+docker compose -f docker-compose.prod.yml up -d --build
+# UI: https://<your-host>:4433/noaide/  (Chromium-only, see ADR-001)
+```
+
+### First launch — what to expect
+
+1. Browser opens on `http://localhost:9999/noaide/` (dev) or
+   `https://<host>:4433/noaide/` (prod).
+2. A **welcome overlay** introduces the four headline capabilities;
+   dismiss with `Get Started` or press `?` for the shortcut sheet.
+3. The **session sidebar** populates with whatever JSONL files exist
+   under your watched paths (default `~/.claude/`). Empty? Run any
+   Claude Code / Gemini / Codex session and reload — the watcher
+   picks it up live.
+4. Click a session → the chat panel renders the full conversation
+   (system reminders, thinking blocks, tool calls included).
+5. The bottom tab bar switches between Chat, Files, Network, Teams,
+   Tasks, Plan, Git, Cost, and Settings.
 
 <details>
 <summary><b>Alternative: native (no Docker) workflow</b></summary>
@@ -346,6 +394,16 @@ just dev-front-native
 
 All recipes are in [`justfile`](justfile); a `Makefile` mirror exists
 for users without `just`.
+
+</details>
+
+<details>
+<summary><b>Optional: voice input (Whisper sidecar)</b></summary>
+
+The microphone button in the chat input is wired to a local Whisper
+sidecar that runs as a separate Python process. It is **opt-in**;
+nothing else in noaide depends on it. Setup, env vars, and disable
+flags are documented in [docs/voice-setup.md](docs/voice-setup.md).
 
 </details>
 
@@ -562,6 +620,7 @@ paths.
 | [docs/evidence-loop-details.md](docs/evidence-loop-details.md) | EventEnvelope, Lamport clock, persistence layers, audit-log NDJSON schema |
 | [docs/component-reference.md](docs/component-reference.md) | Per-module reference: what each crate/module owns, what it publishes, where its config lives |
 | [docs/deployment-guide.md](docs/deployment-guide.md) | Operator guide: Docker compose, systemd, TLS, browser support |
+| [docs/voice-setup.md](docs/voice-setup.md) | Optional Whisper sidecar setup for the microphone input |
 | [docs/adr/001-production-deployment.md](docs/adr/001-production-deployment.md) | ADR-001: production deployment is single-process container, Chromium-only |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Branch flow, commit discipline, PR checklist |
 | [SECURITY.md](SECURITY.md) | Security controls in place and on the roadmap |

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -9,6 +9,13 @@ explains *how* to actually deploy it.
 > **Status**: production target was decided in ADR-001 on 2026-04-26.
 > The smoke test in CI exercises this exact path on every push to main.
 
+> **No pre-built image yet.** noaide does not publish a Docker Hub or
+> GHCR image at this stage. Both deployment paths build from source:
+> Path A runs `docker compose build` (≈ 4–6 min on a recent x86 box),
+> Path B runs `cargo build --release` (≈ 6–10 min). When the project
+> moves out of pre-alpha we will publish a signed image and update
+> this guide.
+
 ## Prerequisites
 
 - Linux host with Docker (or Podman with `docker-compose` shim)

--- a/docs/voice-setup.md
+++ b/docs/voice-setup.md
@@ -1,0 +1,121 @@
+# Voice Input Setup (Whisper Sidecar)
+
+The microphone button in the chat input field streams audio to a
+local Whisper transcription sidecar. The sidecar is **optional** —
+nothing else in noaide depends on it. If you do not need voice input,
+skip this page and set `ENABLE_WHISPER=false` to silence the
+"sidecar failed to start" warning in the backend log.
+
+> **Status**: voice-to-text is wired end-to-end (AudioWorklet PCM
+> capture → WebSocket proxy → faster-whisper → partial+final text
+> back into the input field). The sidecar runs as a separate Python
+> process the Rust backend supervises.
+
+## What it does
+
+| Stage | Component |
+|-------|-----------|
+| Capture | `frontend/src/workers/pcm-capture.worklet.js` — 16 kHz mono int16 PCM via AudioWorklet |
+| Transport | `/api/ws/transcribe` — Rust WebSocket proxy in the backend |
+| Transcribe | `server/whisper/server.py` — FastAPI WebSocket server, faster-whisper model |
+| Render | `frontend/src/hooks/useVoiceInput.ts` — partials live in the textarea, final text appended |
+
+## Prerequisites
+
+| Dependency | Notes |
+|------------|-------|
+| Python | 3.10 – 3.12 |
+| `faster-whisper` | 1.1+ (pulls in `ctranslate2` 4.5+) |
+| `fastapi` + `uvicorn` | WebSocket server |
+| `numpy` | PCM buffer handling |
+| Optional: NVIDIA GPU | `cuDNN 9` + `cuBLAS` for `WHISPER_DEVICE=cuda` (CTranslate2 4.5+ requires cuDNN 9) |
+
+CPU-only is supported (`WHISPER_DEVICE=cpu`). On a recent x86 box,
+the `small` model transcribes a 2-second utterance in ~1 s on CPU
+or ~130 ms on a CUDA GPU (warm).
+
+## Install
+
+The backend looks for a Python interpreter at `WHISPER_PYTHON`
+(default: `/venv/bin/python`). Point it at a venv with the deps
+installed:
+
+```bash
+# Option A — dedicated project venv
+python3 -m venv /work/noaide/.venv-whisper
+source /work/noaide/.venv-whisper/bin/activate
+pip install --upgrade pip
+pip install faster-whisper fastapi uvicorn numpy
+# For CUDA: also install the matching cuDNN/cuBLAS pip wheels
+pip install nvidia-cudnn-cu12 nvidia-cublas-cu12
+
+# Then point the backend at it
+export WHISPER_PYTHON=/work/noaide/.venv-whisper/bin/python
+
+# Option B — system-wide venv (if you already have one)
+export WHISPER_PYTHON=/path/to/venv/bin/python
+```
+
+## Configure
+
+All variables are optional; defaults shown.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ENABLE_WHISPER` | `true` | Set to `false` to skip spawning the sidecar |
+| `WHISPER_PYTHON` | `/venv/bin/python` | Path to the Python interpreter with the deps installed |
+| `WHISPER_PORT` | `8082` | Port the FastAPI server listens on |
+| `WHISPER_MODEL_SIZE` | `small` | `tiny` / `base` / `small` / `medium` / `large-v3` |
+| `WHISPER_LANGUAGE` | `de` | ISO 639-1 language code (`en`, `fr`, …) |
+| `WHISPER_DEVICE` | `cuda` | `cuda` or `cpu` — falls back to CPU if CUDA fails |
+| `WHISPER_COMPUTE_TYPE` | `float16` (cuda) / `int8` (cpu) | CTranslate2 compute precision |
+
+The sidecar caches model files in `~/.cache/huggingface/`. The
+first run downloads the model (~150 MB for `small`).
+
+## Verify it works
+
+```bash
+# 1. Backend log shows the sidecar spawned
+grep "spawning whisper sidecar" /tmp/noaide-server.log
+#  → spawning whisper sidecar port=8082
+
+# 2. The sidecar answers
+ss -ltnp | grep 8082
+#  → LISTEN  0  2048  0.0.0.0:8082
+
+# 3. In the browser at /noaide/, click the mic button in the chat
+#    input. You should see a red "recording" indicator and partial
+#    text appearing in the input field as you speak.
+```
+
+If the backend log shows
+`failed to spawn whisper sidecar … No such file or directory`,
+`WHISPER_PYTHON` is wrong — the path must be a working
+Python interpreter, not the venv directory itself.
+
+If the sidecar starts but exits with `SIGABRT` immediately, you are
+on `WHISPER_DEVICE=cuda` without cuDNN 9 — either install the
+`nvidia-cudnn-cu12` wheel into the venv, or set
+`WHISPER_DEVICE=cpu`.
+
+## Disabling voice input
+
+Two options:
+
+```bash
+# Skip spawning the sidecar entirely
+ENABLE_WHISPER=false ./target/release/noaide-server
+
+# Or hide the mic button in the UI
+ENABLE_AUDIO=false ./target/release/noaide-server
+# (this also silences UI sound cues)
+```
+
+The chat input keeps working without the mic; voice is purely
+additive.
+
+## See also
+
+- [README — Quick Start](../README.md#quick-start) — base setup
+- [docs/component-reference.md](component-reference.md) — sidecar lifecycle and supervision


### PR DESCRIPTION
## Summary
Closes the four honest documentation gaps a new reader hits today:

- **No Docker Hub image yet** — both paths build from source, ~4–10 min first run. Stated upfront in Quick Start and at the top of the deployment guide.
- **Dev vs. prod not separated** — Quick Start now has a *Try it (dev, hot-reload)* and a *Deploy it (production, single container)* subsection, so users land on the right path.
- **Voice/Whisper sidecar was undocumented** — new `docs/voice-setup.md` (Python venv, env vars, CUDA vs CPU, troubleshooting, disable flags) and a collapsed pointer in the README.
- **First-launch expectations missing** — short "what you'll see" section: welcome overlay, session sidebar populated from `~/.claude/`, tab bar.

Also added an explicit *What you also need (outside noaide)* note pointing at Claude Code / Gemini CLI / Codex, since noaide does not ship the agent.

## Test plan
- [x] `git diff` reviewed — no German strings introduced (Language Gate)
- [ ] CI Gate green
- [ ] CodeQL Gate green
- [ ] Conventional Commits green
- [ ] Visual review on github.com — Quick Start sub-headings render cleanly, voice-setup.md link works
- [ ] No broken cross-links from README to deployment-guide / ADR-001 / voice-setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)