### PR TITLE
docs(readme): operator-tone reframing + status matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,31 @@ cellular seamless handoff). Voice input via Web Speech API.
 </tr>
 </table>
 
+## Status
+
+What works today versus what is on the roadmap. Pre-alpha — the buckets
+will move as the project matures.
+
+| Bucket | Definition |
+|---|---|
+| **Implemented** | Code on `main` and exercised by tests in CI. |
+| **Demo-backed** | Code on `main` plus a screenshot or E2E fixture under `docs/images/` or `frontend/e2e/fixtures/`. |
+| **Partial** | Code on `main` but with a UI gap or pending polish. |
+| **Roadmap** | An open issue, no code yet. |
+
+| Capability | Status |
+|---|---|
+| JSONL parser (Claude Code / Codex / Gemini CLI) | Implemented |
+| Codex session spawn with `OPENAI_BASE_URL` proxy routing | Implemented |
+| API proxy with provider detection (Anthropic / OpenAI / Google) | Implemented |
+| eBPF file watcher with PID attribution (inotify fallback) | Implemented |
+| Manual intercept gate (auto / manual / forward / drop / drain) | Demo-backed |
+| Audit export endpoint (NDJSON) | Partial |
+| Conflict resolution (OT buffer + 3-way merge UI) | Partial |
+| Cost dashboard (token tracking; real-dollar costs pending) | Partial |
+| Multi-account control plane | Roadmap ([#108](https://github.com/silentspike/noaide/issues/108)) |
+| Onboarding, keyboard help, ARIA, custom themes | Roadmap ([#107](https://github.com/silentspike/noaide/issues/107)) |
+
 ## Gallery
 
 > Screenshots captured from a local development build against seeded

--- a/README.md
+++ b/README.md
@@ -1,22 +1,10 @@
 <div align="center">
 
-```
-                        $$\       $$\
-                        \__|      $$ |
- $$$$$$$\   $$$$$$\  $$\ $$$$$$\  $$$$$$\   $$$$$$\
-$$  __$$\ $$  __$$\ $$ |$$  __$$\ $$  __$$\ $$  __$$\
-$$ |  $$ |$$ /  $$ |$$ |$$ /  $$ |$$$$$$$$ |$$$$$$$$ |
-$$ |  $$ |$$ |  $$ |$$ |$$ |  $$ |$$   ____|$$   ____|
-$$ |  $$ |\$$$$$$  |$$ |\$$$$$$  |\$$$$$$$\ \$$$$$$$\
-\__|  \__| \______/ \__| \______/  \_______| \_______|
-```
+# noaide
 
 **Browser-based real-time IDE for AI coding agents**
 
-See everything your AI writes. Control every session. Catch every API call.
-
-Requires your AI coding agent running in the background. Not included — you know who's watching. 👀
-<br>The Truman Show × Westworld × The Sims — fully under your control.
+Operator console for AI coding agents. Observe Codex / Claude Code / Gemini CLI sessions, inspect API and tool activity, gate risky requests, and export evidence.
 
 <br>
 


### PR DESCRIPTION
## Summary
- Replaces the ASCII logo + Truman/Westworld/Sims framing in the README top with a one-line H1, the existing tagline, and an operator-console lead sentence that names Codex / Claude Code / Gemini CLI explicitly.
- Adds a `## Status` section between `## What It Does` and `## Gallery` with four buckets (Implemented / Demo-backed / Partial / Roadmap) and ten capability rows. Roadmap entries link to open issues #107 and #108.

## Why
Audit-driven first-viewport polish for the OpenAI Codex application. The old framing reads as entertainment for what is a trust-and-deployment surface; the new framing names what the tool is for and gives a clean cut between shipped and roadmap features.

## Test plan
- [x] Visual review of `README.md` lines 1–30 — operator tone, no surveillance/Truman vocabulary.
- [x] `grep -inE "truman|westworld|the sims|who'?s watching" README.md` → 0 hits.
- [x] `grep -n "Codex / Claude Code / Gemini CLI" README.md` → present at line 7.
- [x] Status section position: `## Status` (line 99) sits between `## What It Does` (33) and `## Gallery` (124).
- [x] All Roadmap-bucket rows reference an open issue (`#107`, `#108`) — verified via `gh issue view`.
- [ ] CI Language Gate green on this PR (will confirm after CI run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)