### PR TITLE
chore: wording, workshop doc, fixture pseudonymisation, source paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,9 @@ noaide never executes or invokes them.
   command, it runs on the host — noaide records it but does not sit in
   between.
 - It does not mask or filter agent output. Everything the JSONL
-  contains — including `system-reminder`, hidden instructions,
-  thinking blocks, and compressed replies — is rendered.
+  contains — including `system-reminder`, system prompts and provider
+  transcript fields the official UI does not surface, intermediate
+  transcript events, and compressed replies — is rendered.
 
 ## 2. Supervision Boundaries
 

--- a/README.md
+++ b/README.md
@@ -665,6 +665,7 @@ paths.
 | [docs/component-reference.md](docs/component-reference.md) | Per-module reference: what each crate/module owns, what it publishes, where its config lives |
 | [docs/deployment-guide.md](docs/deployment-guide.md) | Operator guide: Docker compose, systemd, TLS, browser support |
 | [docs/voice-setup.md](docs/voice-setup.md) | Optional Whisper sidecar setup for the microphone input |
+| [docs/workshop-codex-rollout.md](docs/workshop-codex-rollout.md) | 45-minute hands-on workshop: observe, intercept, rehearse failure modes, export the audit log |
 | [docs/adr/001-production-deployment.md](docs/adr/001-production-deployment.md) | ADR-001: production deployment is single-process container, Chromium-only |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Branch flow, commit discipline, PR checklist |
 | [SECURITY.md](SECURITY.md) | Security controls in place and on the roadmap |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Operator console for AI coding agents. Observe Codex / Claude Code / Gemini CLI 
 
 ## The Problem
 
-AI coding agents like [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Gemini CLI](https://github.com/google-gemini/gemini-cli), and [Codex](https://github.com/openai/codex) generate rich conversation logs (JSONL) containing system prompts, hidden instructions, thinking blocks, tool calls, and results. Their terminal UIs show roughly **60% of this data** — the rest is suppressed.
+AI coding agents like [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Gemini CLI](https://github.com/google-gemini/gemini-cli), and [Codex](https://github.com/openai/codex) generate rich conversation logs (JSONL) containing system prompts, provider transcript fields the official UI does not surface, intermediate transcript events, tool calls, and results. Their terminal UIs show roughly **60% of this data** — the rest is suppressed.
 
 noaide makes 100% visible.
 
@@ -39,7 +39,7 @@ noaide makes 100% visible.
 ### Full JSONL Transparency
 
 Every message rendered — including `system-reminder`,
-thinking blocks, and content marked "don't display."
+intermediate transcript events, and content marked "don't display."
 Compressed messages shown as ghost messages at 30%
 opacity. Nothing hidden, nothing filtered.
 
@@ -415,7 +415,7 @@ docker compose -f docker-compose.prod.yml up -d --build
    Claude Code / Gemini / Codex session and reload — the watcher
    picks it up live.
 4. Click a session → the chat panel renders the full conversation
-   (system reminders, thinking blocks, tool calls included).
+   (system reminders, intermediate transcript events, tool calls included).
 5. The bottom tab bar switches between Chat, Files, Network, Teams,
    Tasks, Plan, Git, Cost, and Settings.
 

--- a/crates/togaf-parser/tests/fixtures/noaide-impl-plan.md
+++ b/crates/togaf-parser/tests/fixtures/noaide-impl-plan.md
@@ -229,7 +229,7 @@ noaide ist eine Browser-basierte IDE die Claude Code Sessions in Echtzeit visual
 
 | Stakeholder | Rolle | Concern | Einfluss |
 |------------|-------|---------|----------|
-| Jan (User/Dev) | Primaer-Nutzer, Allein-Entwickler | Volle Transparenz, Performance, Mobile-Zugang | High |
+| Operator (User/Dev) | Primaer-Nutzer, Allein-Entwickler | Volle Transparenz, Performance, Mobile-Zugang | High |
 | Claude Code | AI Agent (wird gesteuert) | Session-Stabilitaet, kein Session-Neustart | High |
 | Anthropic API | Externer Service | Rate Limits, API-Kompatibilitaet | Medium |
 | Browser (Chrome/Firefox) | Runtime-Umgebung | WebTransport Support, SharedArrayBuffer, COOP/COEP | Medium |
@@ -239,10 +239,10 @@ noaide ist eine Browser-basierte IDE die Claude Code Sessions in Echtzeit visual
 
 | Aktivitaet | Responsible | Accountable | Consulted | Informed |
 |-----------|------------|-------------|-----------|----------|
-| Architecture | Claude (LLM) | Jan | Peer-Review LLMs | - |
-| Implementation | Claude (LLM) | Jan | - | - |
-| Testing | Claude (LLM) | Jan | - | - |
-| Deployment | Jan | Jan | - | - |
+| Architecture | Claude (LLM) | Operator | Peer-Review LLMs | - |
+| Implementation | Claude (LLM) | Operator | - | - |
+| Testing | Claude (LLM) | Operator | - | - |
+| Deployment | Operator | Operator | - | - |
 
 ---
 
@@ -292,14 +292,14 @@ noaide ist eine Browser-basierte IDE die Claude Code Sessions in Echtzeit visual
 
 | ID | Requirement | Typ | Prioritaet | Source |
 |----|------------|-----|-----------|--------|
-| REQ-1 | ALLE JSONL-Inhalte anzeigen (inkl. hidden, system-reminder, thinking) | Functional | Must | Jan |
+| REQ-1 | ALLE JSONL-Inhalte anzeigen (inkl. hidden, system-reminder, thinking) | Functional | Must | Operator |
 | REQ-2 | File-Event-to-Browser Latenz < 50ms (p99) | Non-Functional | Must | Tech-Philosophie |
 | REQ-3 | 120Hz Rendering bei 1000+ Messages | Non-Functional | Must | Tech-Philosophie |
-| REQ-4 | Bidirektionale Session-Steuerung (PTY stdin + tmux send-keys) | Functional | Must | Jan |
-| REQ-5 | API Proxy mit vollstaendigem Request/Response Logging | Functional | Must | Jan |
-| REQ-6 | Multi-Agent Topology Graph mit animierten Message-Bubbles | Functional | Must | Jan |
-| REQ-7 | Interactive Gantt mit Time-Tracking pro Agent | Functional | Should | Jan |
-| REQ-8 | Mobile Layout mit Bottom Tab Bar und Swipe | Functional | Should | Jan |
+| REQ-4 | Bidirektionale Session-Steuerung (PTY stdin + tmux send-keys) | Functional | Must | Operator |
+| REQ-5 | API Proxy mit vollstaendigem Request/Response Logging | Functional | Must | Operator |
+| REQ-6 | Multi-Agent Topology Graph mit animierten Message-Bubbles | Functional | Must | Operator |
+| REQ-7 | Interactive Gantt mit Time-Tracking pro Agent | Functional | Should | Operator |
+| REQ-8 | Mobile Layout mit Bottom Tab Bar und Swipe | Functional | Should | Operator |
 | REQ-9 | Server < 200MB RSS, Browser < 500MB | Non-Functional | Must | Hardware |
 | REQ-10 | WebTransport mit Adaptive Quality (RTT-basiert) | Functional | Must | Mobile-First |
 | REQ-11 | eBPF File Watching mit PID-Tracing (welcher Prozess schreibt) | Functional | Must | Conflict Resolution |
@@ -852,7 +852,7 @@ Bei Reconnect: Server sendet Snapshot des aktuellen States + Delta der verpasste
 | R-5 | 120Hz Rendering-Performance | High | Medium | UI ruckelt, schlechte UX | SolidJS fine-grained; Virtual Scroller; Web Workers; GPU CSS | Claude |
 | R-6 | JSONL-Files >100MB | Medium | High | Langsamer Start, OOM | Streaming Parser, nur sichtbare Messages im DOM, Limbo Indexing | Claude |
 | R-7 | PTY-Management Komplexitaet | Medium | Medium | Session-Instabilitaet | portable-pty crate; tmux als Fallback | Claude |
-| R-8 | Scope Creep | High | High | Projekt nicht fertig | Strikte Phase 1 Scope-Grenze; Out of Scope klar definiert | Jan |
+| R-8 | Scope Creep | High | High | Projekt nicht fertig | Strikte Phase 1 Scope-Grenze; Out of Scope klar definiert | Operator |
 | R-9 | WebTransport Self-Signed Cert Rejection | High | High | Browser lehnt QUIC ab | mkcert lokale CA + Trust Store (WP-0) | Claude |
 | R-10 | Event-Ordering Race Conditions | Medium | Medium | UI-Inkonsistenzen, Doubles | EventEnvelope mit Lamport Clock + Dedup | Claude |
 | R-11 | Backpressure bei Event-Spikes | Medium | Medium | Queue-Overflow, Lag | Bounded channels + Drop-Policy (C.2) | Claude |
@@ -1506,7 +1506,7 @@ WP-0 → WP-1 → WP-2 → WP-4 → WP-5 → WP-7 → WP-8 → WP-9 → WP-19
 | **Contract/API** | **N/A** — keine externen API-Consumer | - | - |
 | **System/Artifact** | Binary black-box | Main | Server starten + Health Check |
 | **E2E/Smoke** | Kritische User-Journeys | Nightly | Playwright |
-| **UAT** | Fachliche Freigabe | Release | Jan's manuelle Pruefung |
+| **UAT** | Fachliche Freigabe | Release | Operator's manuelle Pruefung |
 | **Non-Functional** | Performance/Resilienz | Nightly | `cargo bench` + FPS Profiler |
 
 ### Unit Tests
@@ -1710,7 +1710,7 @@ WP-0 → WP-1 → WP-2 → WP-4 → WP-5 → WP-7 → WP-8 → WP-9 → WP-19
 - [ ] `/work/noaide/.claude/CLAUDE.md` — Projekt-spezifische Instructions
 - [ ] `/work/noaide/docs/architecture.md` — Detaillierte Architektur
 - [ ] `/work/noaide/docs/api.md` — WebTransport API Docs
-- [ ] `/home/jan/.claude/CLAUDE.md` — noaide Verweis ergaenzen
+- [ ] `~/.claude/CLAUDE.md` — noaide Verweis ergaenzen
 
 ### HTML-Dashboard: Lebendes Dokument (PFLICHT!)
 
@@ -1803,14 +1803,14 @@ _Noch keine Lessons — werden waehrend VERIFY geschrieben und hier referenziert
 
 | ID | Requirement | Typ | Quelle | Status | Prioritaet | Phase |
 |----|------------|-----|--------|--------|-----------|-------|
-| REQ-1 | ALLE JSONL-Inhalte anzeigen | Func | Jan | Accepted | Must | A |
+| REQ-1 | ALLE JSONL-Inhalte anzeigen | Func | Operator | Accepted | Must | A |
 | REQ-2 | File-Event Latenz <50ms p99 | Non-Func | Tech | Accepted | Must | A |
 | REQ-3 | 120Hz bei 1000+ Messages | Non-Func | Tech | Accepted | Must | A |
-| REQ-4 | Bidirektionale Session-Steuerung | Func | Jan | Accepted | Must | A |
-| REQ-5 | API Proxy mit Logging | Func | Jan | Accepted | Must | A |
-| REQ-6 | Multi-Agent Topology Graph | Func | Jan | Accepted | Must | A |
-| REQ-7 | Interactive Gantt | Func | Jan | Accepted | Should | A |
-| REQ-8 | Mobile Layout | Func | Jan | Accepted | Should | A |
+| REQ-4 | Bidirektionale Session-Steuerung | Func | Operator | Accepted | Must | A |
+| REQ-5 | API Proxy mit Logging | Func | Operator | Accepted | Must | A |
+| REQ-6 | Multi-Agent Topology Graph | Func | Operator | Accepted | Must | A |
+| REQ-7 | Interactive Gantt | Func | Operator | Accepted | Should | A |
+| REQ-8 | Mobile Layout | Func | Operator | Accepted | Should | A |
 | REQ-9 | Server <200MB, Browser <500MB | Non-Func | HW | Accepted | Must | A |
 | REQ-10 | Adaptive Quality (RTT) | Func | Mobile | Accepted | Must | A |
 | REQ-11 | eBPF PID-Tracing | Func | Conflict Res. | Accepted | Must | A |
@@ -1824,15 +1824,15 @@ _Noch keine Lessons — werden waehrend VERIFY geschrieben und hier referenziert
 
 | ID | Aenderung | Begruendung | Impact | Status | Entscheidung |
 |----|---------|-----------|--------|--------|-------------|
-| CHG-1 | Event-Ordering Protokoll hinzufuegen | Peer-Review Codex: Race Conditions | C.2, alle WPs | Accepted | 2026-02-20, Jan |
-| CHG-2 | Backpressure-Strategie hinzufuegen | Peer-Review Codex: Queue Overflow | C.2, WP-6, WP-7 | Accepted | 2026-02-20, Jan |
-| CHG-3 | COOP/COEP + Self-hosted Fonts | Peer-Review Codex: SharedArrayBuffer | C.4, WP-0 | Accepted | 2026-02-20, Jan |
-| CHG-4 | mkcert fuer WebTransport TLS | Peer-Review Gemini: Cert Rejection | C.4, WP-0 | Accepted | 2026-02-20, Jan |
-| CHG-5 | Breathing Orb Dual-Source | Peer-Review Gemini: Status-Quelle | WP-9 | Accepted | 2026-02-20, Jan |
-| CHG-6 | Conflict Resolution OT Buffer | Peer-Review Gemini+Claude: Concurrent Edits | WP-10 | Accepted | 2026-02-20, Jan |
-| CHG-7 | TOGAF ADM Format Migration | Skill-Update /impl-plan v2.0 | Plan-Struktur | Accepted | 2026-02-20, Jan |
-| CHG-8 | Peer-Review Fixes (10 Items) | Codex+Gemini Review v2.0 | 8 Sektionen (P.2,P.4,A.4,B.3,C.3,F.1,G.3,RM.3 + 3 WPs) | Accepted | 2026-02-20, Jan |
-| CHG-9 | Living Document Policy | HTML-Dashboard muss lebendes Dokument sein | P.2 (Prinzip), G.5 (Update-Policy) | Accepted | 2026-02-20, Jan |
+| CHG-1 | Event-Ordering Protokoll hinzufuegen | Peer-Review Codex: Race Conditions | C.2, alle WPs | Accepted | 2026-02-20, Operator |
+| CHG-2 | Backpressure-Strategie hinzufuegen | Peer-Review Codex: Queue Overflow | C.2, WP-6, WP-7 | Accepted | 2026-02-20, Operator |
+| CHG-3 | COOP/COEP + Self-hosted Fonts | Peer-Review Codex: SharedArrayBuffer | C.4, WP-0 | Accepted | 2026-02-20, Operator |
+| CHG-4 | mkcert fuer WebTransport TLS | Peer-Review Gemini: Cert Rejection | C.4, WP-0 | Accepted | 2026-02-20, Operator |
+| CHG-5 | Breathing Orb Dual-Source | Peer-Review Gemini: Status-Quelle | WP-9 | Accepted | 2026-02-20, Operator |
+| CHG-6 | Conflict Resolution OT Buffer | Peer-Review Gemini+Claude: Concurrent Edits | WP-10 | Accepted | 2026-02-20, Operator |
+| CHG-7 | TOGAF ADM Format Migration | Skill-Update /impl-plan v2.0 | Plan-Struktur | Accepted | 2026-02-20, Operator |
+| CHG-8 | Peer-Review Fixes (10 Items) | Codex+Gemini Review v2.0 | 8 Sektionen (P.2,P.4,A.4,B.3,C.3,F.1,G.3,RM.3 + 3 WPs) | Accepted | 2026-02-20, Operator |
+| CHG-9 | Living Document Policy | HTML-Dashboard muss lebendes Dokument sein | P.2 (Prinzip), G.5 (Update-Policy) | Accepted | 2026-02-20, Operator |
 
 ---
 

--- a/docs/end-to-end-validation.md
+++ b/docs/end-to-end-validation.md
@@ -170,8 +170,8 @@ benchmark, etc.). Each row is one assertion. Status:
 - [~] **Spawn a managed Claude session via `/api/sessions/managed`** — UNTESTED in this run (would consume real API calls); managed-session code path was verified separately during the prior sprints
 - [x] **JSONL discovery + parse against real `~/.claude/projects/...`** — Evidence:
   ```
-  $ env -i HOME=/home/jan PATH=... \
-      NOAIDE_WATCH_PATHS=/home/jan/.claude \
+  $ env -i HOME="$HOME" PATH=... \
+      NOAIDE_WATCH_PATHS="$HOME/.claude" \
       target/release/noaide-server &
   $ wget -q -O - http://localhost:8080/api/sessions | python3 -c \
       "import json,sys; print(len(json.load(sys.stdin)))"

--- a/docs/show-hn-draft.md
+++ b/docs/show-hn-draft.md
@@ -21,12 +21,13 @@ https://github.com/silentspike/noaide
 
 ## First comment (the one HN expects from the OP)
 
-> noaide is a self-hosted, browser-based IDE for watching AI coding
-> agents (Claude Code, Gemini CLI, Codex) live as they work. The agent
-> stays in your terminal where you started it; noaide attaches and
-> renders every JSONL log line — including the parts the agent's
-> own UI suppresses (system-reminders, hidden instructions, thinking
-> blocks, tool-use envelopes).
+> noaide is a self-hosted, browser-based operator console for AI coding
+> agents (Claude Code, Gemini CLI, Codex) — an observation surface and
+> supervision boundary while they work. The agent stays in your
+> terminal where you started it; noaide attaches and renders every
+> JSONL log line — including the parts the agent's own UI suppresses
+> (system-reminders, system prompts and provider transcript fields,
+> intermediate transcript events, tool-use envelopes).
 >
 > What it gives you:
 >

--- a/docs/workshop-codex-rollout.md
+++ b/docs/workshop-codex-rollout.md
@@ -1,0 +1,264 @@
+# Workshop — Operating Codex with noaide
+
+> Forty-five minute hands-on session for engineering leads and
+> trust-and-deployment specialists who need to validate Codex sessions
+> as a deployment-grade workflow before rolling them out across an
+> organisation.
+
+This workshop assumes a Codex installation that the participant
+controls and a noaide instance running on the participant's laptop or
+on a small shared host. The goal is not to teach Codex; the goal is to
+show how the operator stays in the loop while Codex is running.
+
+---
+
+## Audience
+
+- Engineering leads piloting Codex inside a team.
+- Trust-and-deployment specialists writing the rollout checklist for
+  Codex (or Claude Code, or Gemini CLI).
+- Solution architects asked to put a supervision surface around an
+  agent before it is approved for use against production code.
+
+The audience does not need to be a Rust or SolidJS developer. They do
+need to be comfortable with shell, TLS, and `gh`/`gcloud`-class tools.
+
+## Pre-flight (5 min)
+
+Before the session starts, confirm each participant has:
+
+- A laptop with Docker (or Podman with the `docker-compose` shim).
+- A noaide checkout from `main`. `just certs` and
+  `docker compose -f docker-compose.prod.yml up -d --build` must
+  complete cleanly.
+- A Codex installation (`codex --version` should return a version).
+- A TLS chain noaide trusts. mkcert or a corporate CA both work — see
+  `docs/deployment-guide.md` for the three supported sources.
+- A working API key for Codex (or another OpenAI-compatible provider)
+  exported as `OPENAI_API_KEY`.
+
+If any of those is missing, fix it before block 1; the demo flow does
+not work without them.
+
+## Agenda
+
+The four blocks below add up to forty minutes. The remaining five
+minutes are for the pre-flight check above and a closing review.
+
+### Block 1 — Observation (10 min)
+
+Goal: convince the participant that nothing the agent does is hidden.
+
+1. Spawn a Codex session normally (no proxy, no special env).
+2. Open the noaide UI in Chromium at the URL the deployment guide
+   prints. Pick the new session card from the sidebar.
+3. As the participant prompts Codex with a non-trivial task ("rename
+   the `Foo` type to `Bar` and update its tests"), watch the chat
+   panel render every JSONL event live: `turn_context`,
+   `agent_reasoning`, `agent_message`, `response_item`,
+   `compacted` summaries.
+4. Show the `system-reminder` and provider transcript fields. The
+   official Codex CLI usually suppresses them; noaide does not.
+5. Switch to the Files tab and show eBPF or inotify file events with
+   PID attribution. Every change the agent makes shows up here, in
+   real time, attributed to the right process.
+
+Discussion prompt: *if your team adopts Codex tomorrow, who reads
+this transcript and how often?*
+
+### Block 2 — Intercept and gate (10 min)
+
+Goal: show that the operator can hold and modify a request before it
+leaves the host.
+
+1. Restart Codex with the noaide proxy:
+
+   ```bash
+   export OPENAI_BASE_URL="http://localhost:4434/s/${SESSION_ID}/backend-api/codex"
+   export OPENAI_API_KEY=…
+   codex
+   ```
+
+2. In the noaide Network tab, switch the proxy mode from **Auto** to
+   **Manual**.
+3. Prompt Codex again. The next request will be held in the manual
+   gate; the request body shows up in the inspector pane.
+4. Modify a header, edit the body, then **Forward**. Codex receives
+   the modified request and continues.
+5. Repeat once more, but this time **Drop** the request. Codex sees
+   the failure and reports it back to the participant in plain
+   English.
+
+Discussion prompt: *which requests would your team gate by default,
+and which would you let through automatically?*
+
+### Block 3 — Failure modes (10 min)
+
+Goal: rehearse the three most common failure modes so they are not
+surprises when they happen in production.
+
+1. **Cert chain broken.** Replace `certs/cert.pem` with a wrong
+   certificate and reload the page. The browser console shows the
+   exact failure. Walk through the `NODE_EXTRA_CA_CERTS` /
+   `CODEX_CA_CERTIFICATE` / `SSL_CERT_FILE` recovery in
+   `docs/deployment-guide.md`.
+2. **Proxy crash.** `kill -9` the noaide-server process. Codex falls
+   back to the upstream depending on env variables; observe what the
+   participant's checklist should say about that fallback.
+3. **Unknown JSONL event.** Append a synthetic line with an unknown
+   `type` to a fixture and observe how noaide preserves it as a
+   meta event instead of dropping it. The transcript stays
+   loss-free even when a provider extends its schema.
+
+Discussion prompt: *how does your incident playbook reference each
+of these failure modes today?*
+
+### Block 4 — Audit export and review (10 min)
+
+Goal: produce a deliverable that survives outside the workshop.
+
+1. Open the Network tab → Custom mode → expand **Audit Log**.
+2. Click **JSON** to download the NDJSON-shaped audit log for the
+   session that just ran.
+3. Walk through the JSON line by line. Each entry maps a captured
+   request and response back to a session id, a model, a redacted
+   payload, and timing.
+4. Show the same data exported as CSV via the **CSV** button.
+5. Check the redaction. `sk-…` keys, `Bearer …` tokens, and
+   provider account ids are masked in both the on-screen request
+   list and the exported audit log.
+
+Discussion prompt: *which downstream system would consume this audit
+log in your org — SIEM, ticketing, finance, or all three?*
+
+---
+
+## Safety boundaries — what noaide does NOT enforce
+
+This is the most important section of the workshop. noaide is a
+supervision surface, not a policy engine. See
+[supervision-boundaries.md](supervision-boundaries.md) for the full
+contract, but at a glance:
+
+- noaide does **not** mediate tool execution. When the agent runs a
+  shell command, it runs on the host. noaide records it.
+- noaide does **not** prevent the agent from reading files. It tells
+  the operator which files the agent read, and when.
+- noaide does **not** filter agent output. It renders everything the
+  JSONL contains.
+- noaide does **not** sign, encrypt, or attest the audit log. If the
+  audit log volume is mutable, treat it as advisory.
+- noaide does **not** replace the operator. If nobody reads the
+  audit log, the audit log is just storage.
+
+If the rollout requires hard policy enforcement (deny-list of shell
+commands, outbound-network firewall, signed audit) the team needs to
+add those layers around noaide. noaide gives the operator the visibility
+to write those layers correctly; it does not become them.
+
+## Rollout checklist
+
+Use this as a starting point for a customer-facing checklist. Adapt
+the wording but keep the categories.
+
+- **TLS provisioning.** LetsEncrypt for public-internet hosts,
+  corporate CA for intranet hosts, mkcert only for localhost. Document
+  who owns renewal.
+- **Secret hygiene.** `NOAIDE_JWT_SECRET` is the only secret noaide
+  generates; rotate via secret manager. Audit log volumes contain
+  redacted bodies — store them in the same tier as access logs, not
+  the public artefact tier.
+- **Network policy.** Egress whitelist for `OPENAI_BASE_URL`,
+  `ANTHROPIC_BASE_URL`, and `CODE_ASSIST_ENDPOINT`. Block direct
+  access to provider endpoints from the agent host so the proxy is
+  always on the path.
+- **Backup.** Audit log NDJSON volume goes to whichever long-term
+  store the org already uses for SIEM input. The Limbo cache is
+  regenerable and does not need a backup policy.
+- **Role separation.** The operator user that reads the audit log
+  must not be the same identity the agent uses to call providers.
+  Same machine is fine; same login is not.
+- **Browser scope.** Pre-alpha is Chromium only (ADR-001). Document
+  the Chrome / Edge / Brave / Arc / Opera support and the explicit
+  Firefox / Safari gap.
+
+## Failure modes — extended notes
+
+These are the three failure modes block 3 rehearses, plus two more
+the participant will probably hit within their first week.
+
+### eBPF capabilities are missing
+
+Symptom: the file events panel shows no PID attribution and the
+backend logs `eBPF unavailable, falling back to inotify`.
+
+Cause: the host kernel does not expose `CAP_BPF`, the container does
+not get it, or the kernel is too old.
+
+Recovery: container `--cap-add=BPF --cap-add=PERFMON` for kernels
+≥ 5.8, or `--cap-add=SYS_ADMIN` for older kernels. inotify is a
+working fallback; PID attribution is the only thing you lose.
+
+### Codex changes its rollout schema
+
+Symptom: a new top-level `type` appears that noaide preserves as a
+generic meta event instead of rendering it natively.
+
+Cause: provider extended the schema. noaide is forward-tolerant; it
+will not drop the line, but the visual rendering may not be ideal.
+
+Recovery: open an issue with the new event type and a sanitized
+sample. The parser hot-path is small; adding a new branch is a
+single function in `server/src/parser/codex.rs`.
+
+### The proxy is bypassed
+
+Symptom: a Codex session shows up in the sidebar but no requests
+appear in the Network tab.
+
+Cause: the agent connected directly to the provider instead of the
+proxy. The most common reason is a missing `OPENAI_BASE_URL` export
+in the shell that started the agent.
+
+Recovery: re-export `OPENAI_BASE_URL` and restart the agent. Add the
+egress whitelist mentioned in the rollout checklist so this is
+caught at the network layer next time.
+
+### TLS chain breaks during rotation
+
+Symptom: WebTransport disconnects in the browser; the agent's calls
+to the proxy fail with a TLS error.
+
+Cause: cert renewed, server restarted with old cert path, or the
+intermediate is missing from the chain.
+
+Recovery: confirm `NOAIDE_TLS_CERT` and `NOAIDE_TLS_KEY` point at the
+new pair. Restart the noaide-server. Re-trust the new certificate in
+the agent's environment if it pins via `NODE_EXTRA_CA_CERTS` or
+`CODEX_CA_CERTIFICATE`.
+
+### Audit log volume fills up
+
+Symptom: noaide-server logs that the audit insert failed and the
+Network tab keeps showing recent requests but the export endpoint
+returns truncated data.
+
+Cause: NDJSON volume is full or the underlying disk is.
+
+Recovery: rotate the audit log volume into long-term storage, then
+truncate. Until rotation is automated, monitor disk usage on the
+volume separately from the server health endpoint.
+
+## Closing — what to take home
+
+Three artefacts that should leave the workshop with the participant:
+
+1. The audit-log NDJSON from block 4, pinned in the org's secure
+   storage as the first sample.
+2. The rollout checklist above, adapted to the org's stack and
+   pasted into the customer-facing runbook.
+3. One concrete decision: which proxy mode is the default for which
+   class of request.
+
+If any of those three is missing at the end of the workshop, the
+rollout is not yet ready.

--- a/server/src/discovery/scanner.rs
+++ b/server/src/discovery/scanner.rs
@@ -648,7 +648,7 @@ pub fn extract_gemini_uuid(filename: &str) -> Option<String> {
 ///
 /// Examples:
 /// - `-work-noaide` → `/work/noaide`
-/// - `-home-jan` → `/home/jan`
+/// - `-home-user` → `/home/user`
 /// - `-work-company--sentinel-tools` → `/work/company/-sentinel-tools`
 ///
 /// Double dashes represent a literal dash in the original path component.
@@ -689,7 +689,7 @@ mod tests {
 
     #[test]
     fn decode_home_path() {
-        assert_eq!(decode_project_dir("-home-jan"), "/home/jan");
+        assert_eq!(decode_project_dir("-home-user"), "/home/user");
     }
 
     #[test]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1838,7 +1838,7 @@ fn extract_project_path_from_jsonl(jsonl_path: &std::path::Path) -> Option<Strin
 /// Decode a Claude Code project directory name back to a filesystem path.
 ///
 /// `-work-noaide` → `/work/noaide`
-/// `-home-jan` → `/home/jan`
+/// `-home-user` → `/home/user`
 ///
 /// WARNING: This decoding is lossy! Claude Code encodes `/` → `-` without
 /// escaping literal hyphens. So `-tmp-test-session` could be either

--- a/server/src/parser/codex.rs
+++ b/server/src/parser/codex.rs
@@ -423,7 +423,7 @@ mod tests {
 
     #[test]
     fn parse_codex_turn_context_extracts_model() {
-        let line = r#"{"timestamp":"2025-10-26T11:55:00Z","type":"turn_context","payload":{"model":"gpt-5.2-codex","cwd":"/home/jan"}}"#;
+        let line = r#"{"timestamp":"2025-10-26T11:55:00Z","type":"turn_context","payload":{"model":"gpt-5.2-codex","cwd":"/home/user"}}"#;
         let entry: CodexLine = serde_json::from_str(line).unwrap();
         let msg = codex_turn_context(&entry);
         assert_eq!(msg.model, Some("gpt-5.2-codex".to_string()));


### PR DESCRIPTION
## Summary
Bundle of four audit-driven polish tasks against the same files set:

- **Wording sanitize.** Replaces *thinking blocks* with *intermediate transcript events*, *hidden instructions* with *system prompts and provider transcript fields the official UI does not surface*, and the *watching AI coding agents* phrasing with *operator console for AI coding agents — an observation surface and supervision boundary*. Technical *file watching* / *watched paths* stays.
- **Codex rollout workshop.** Adds `docs/workshop-codex-rollout.md` (264 lines, four 10-minute blocks: observation, intercept and gate, rehearsed failure modes, audit-log export) and links it from the README documentation index. Cross-links to `docs/supervision-boundaries.md`.
- **Pseudonymise togaf-parser fixture.** 28 instances of a personal first name and one absolute home-directory path in `crates/togaf-parser/tests/fixtures/noaide-impl-plan.md` become `Operator` / `~/.claude/CLAUDE.md`. Parser tests still pass against the structural shape.
- **Generic source paths.** `-home-jan` / `/home/jan` in two doc-comments (`server/src/discovery/scanner.rs`, `server/src/main.rs`), one test assertion (`scanner.rs`), one test JSON literal (`server/src/parser/codex.rs`), and two operator-notes lines (`docs/end-to-end-validation.md`) become `-home-user` / `/home/user` / `\$HOME`.

## Why
Audit findings on first-impression polish: the OpenAI Codex application reads the README in 90 seconds and the supporting docs shortly after. Surveillance-coded vocabulary, an absent workshop artefact, and the operator's literal name in a public test fixture each undermine the trust-and-deployment story the role is about.

## Test plan
- [x] \`grep -rnE "thinking block|hidden instruction" README.md AGENTS.md docs/\` → 0 hits
- [x] \`grep -rnE "watching" README.md AGENTS.md docs/\` → only \`file watching\` / \`watched paths\` remain (technical domain language)
- [x] \`wc -l docs/workshop-codex-rollout.md\` → 264; \`grep -c "^### Block " docs/workshop-codex-rollout.md\` → 4
- [x] \`grep -cwE "Jan" crates/togaf-parser/tests/fixtures/noaide-impl-plan.md\` → 0; \`grep -c "/home/jan" \"\` → 0
- [x] \`cargo remote -c -- test -p togaf-parser\` → 58 passed (45+12+1, 0 failed)
- [x] \`grep -rnE "home/jan|home-jan" server/src/ docs/\` → 0 hits
- [x] \`cargo remote -c -- test -p noaide-server\` → 315 passed
- [x] \`cargo remote -c -- clippy -p noaide-server -- -D warnings\` → 0 warnings (Finished in 4.99s)
- [x] \`cargo remote -c -- fmt -- --check\` → no diffs
- [ ] CI green on this PR (Conventional Commits, Language Gate, CI Gate, CodeQL Gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)