### PR TITLE
docs(certs): document TLS subject sanitization and never-paste guidance

### DIFF
--- a/certs/README.md
+++ b/certs/README.md
@@ -7,18 +7,56 @@ Local TLS certificates for WebTransport (HTTP/3 QUIC) development.
 All `.pem` files in this directory are **gitignored**. Each developer
 generates their own local certificates. Certificates are never committed.
 
-`mkcert` embeds the generator's `OU=<user>@<hostname>` into the certificate
-subject. Since the `.pem` files stay local, this has no public exposure —
-but be aware if you share your Vite dev server, browser DevTools, or
-curl output with others, the certificate subject will contain your
-username and machine hostname.
+`mkcert` embeds the generator's `OU=<user>@<hostname>` into both the
+certificate's **subject** and **issuer**. The `.pem` files stay local, so
+this has no public-tree exposure — but be aware:
 
-If you prefer a neutral subject, generate certificates on a machine with a
-neutral user/hostname (e.g. inside a container), or use raw `openssl` /
-`cfssl` to produce a custom `O=noaide development certificate` subject
-without user/host identifiers.
+- If you share Vite dev-server output, browser DevTools transcripts, or
+  any tool that prints certificate details, the subject and issuer will
+  contain your username and machine hostname.
+- **Never paste the contents of `cert.pem`, `fullchain.pem`, the
+  `openssl x509 -text` output, or screenshots of TLS dialogs into
+  public bug reports, screenshots, or live demos.** Treat them like
+  any other operator-identifying artefact.
 
-## Generate
+### Subject sanitization is tool-specific
+
+`mkcert` always writes a personalised OU because that is its CA's
+identity. There is no `mkcert` flag to override it.
+
+If you need a neutral subject (e.g. recording a demo, publishing
+screenshots, sharing a live session), produce the leaf cert with raw
+OpenSSL and sign it with the existing mkcert CA:
+
+```bash
+CAROOT=$(mkcert -CAROOT)
+
+openssl genrsa -out certs/key.pem 2048
+openssl req -new -key certs/key.pem \
+  -subj "/CN=noaide development certificate/O=noaide" \
+  -out /tmp/csr.pem
+
+cat > /tmp/v3.ext <<'EOF'
+subjectAltName = DNS:noaide.local, DNS:localhost, IP:127.0.0.1, IP:::1
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth
+EOF
+
+openssl x509 -req -in /tmp/csr.pem \
+  -CA "$CAROOT/rootCA.pem" -CAkey "$CAROOT/rootCA-key.pem" -CAcreateserial \
+  -days 825 -sha256 -extfile /tmp/v3.ext \
+  -out certs/cert.pem
+
+openssl x509 -in certs/cert.pem -noout -subject
+# subject=CN=noaide development certificate, O=noaide
+```
+
+The leaf is now neutral. The **issuer** still carries the mkcert CA's
+personalised OU because that CA was generated with `mkcert -install`;
+re-issue from a fresh CAROOT (or a corporate dev CA) if the issuer line
+also needs to be neutral.
+
+## Generate (mkcert default)
 
 ```bash
 # Install mkcert (first time only)


### PR DESCRIPTION
## Summary
mkcert writes a personalised \`OU=<user>@<hostname>\` into the local cert's subject and issuer. The .pem files stay gitignored, but anything that prints cert metadata (\`openssl x509 -text\`, browser TLS dialogs, Vite output) can leak operator identity if pasted into a public bug report or screenshot.

This PR rewrites \`certs/README.md\` with:
- A hard \"never paste cert.pem / openssl output / TLS dialogs\" line.
- An explicit note that mkcert has no flag to override the OU.
- A copy-pasteable OpenSSL recipe that produces a neutral leaf (\`CN=noaide development certificate, O=noaide\`) signed by the existing mkcert CAROOT.
- A note that the issuer line still carries the personalised OU until the operator re-issues from a fresh CAROOT.

## Why
Audit-driven: a leaked cert subject pinned the maintainer's username and home-router hostname. Documenting the recipe (and the boundary of what mkcert can sanitize) closes the gap that the cert-regeneration step from a previous sprint did not.

## Test plan
- [x] Regenerated leaf locally via the recipe; \`openssl x509 -in certs/cert.pem -noout -subject\` → \`subject=CN=noaide development certificate, O=noaide\`. No \`jan@\`, no \`linux.fritz.box\`.
- [x] Backend started against the new cert and handshakes cleanly (logs show \`noaide-server ready\` and a successful WebTransport \`connection established\`).
- [x] \`certs/cert.pem\` and \`certs/key.pem\` remain gitignored — only \`certs/README.md\` is in this PR.
- [ ] CI green on this PR (Conventional Commits, Language Gate, CI Gate, CodeQL Gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)