### PR TITLE
docs(examples): add cookbook walkthroughs and examples/ index

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,7 @@ paths.
 | [docs/deployment-guide.md](docs/deployment-guide.md) | Operator guide: Docker compose, systemd, TLS, browser support |
 | [docs/voice-setup.md](docs/voice-setup.md) | Optional Whisper sidecar setup for the microphone input |
 | [docs/workshop-ai-coding-rollout.md](docs/workshop-ai-coding-rollout.md) | 45-minute tool-agnostic workshop (Codex / Claude Code / Gemini CLI): observe, intercept, rehearse failure modes, export the audit log |
+| [examples/](examples/) | Cookbook walkthroughs: spawn a session, intercept a request, export the audit log |
 | [docs/adr/001-production-deployment.md](docs/adr/001-production-deployment.md) | ADR-001: production deployment is single-process container, Chromium-only |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Branch flow, commit discipline, PR checklist |
 | [SECURITY.md](SECURITY.md) | Security controls in place and on the roadmap |

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,23 @@
+# Examples
+
+Cookbook-style walkthroughs that show one concrete operator task each.
+Each file is self-contained, ≤ 100 lines, and copy-pasteable. They
+assume noaide is running locally — see the
+[Quick Start](../README.md#quick-start) for the one-time setup.
+
+| Walkthrough | What it covers | Tools shown |
+|---|---|---|
+| [`codex-session-spawn.md`](codex-session-spawn.md) | Spawn a managed agent session, route its API calls through the noaide proxy, watch the JSONL transcript | Codex • Claude Code • Gemini CLI |
+| [`intercept-api-request.md`](intercept-api-request.md) | Switch the proxy to manual mode, hold an outbound request, modify it, forward or drop it | Provider-agnostic |
+| [`audit-export-pattern.md`](audit-export-pattern.md) | Pull the NDJSON audit log via `/api/proxy/audit/export`, walk the schema, replay one entry against the chat panel | Provider-agnostic |
+
+More walkthroughs welcome — see [CONTRIBUTING.md](../CONTRIBUTING.md)
+for the contribution flow. Style guide: keep each example ≤ 100 lines,
+prefer the smallest reproducible commands over a full runbook, and
+show the expected output for every command that produces one.
+
+## See also
+
+- [`docs/workshop-ai-coding-rollout.md`](../docs/workshop-ai-coding-rollout.md) — the 45-minute workshop these walkthroughs feed into
+- [`docs/api.md`](../docs/api.md) — the HTTP endpoints the examples call
+- [`docs/agent-operating-model.md`](../docs/agent-operating-model.md) — what noaide watches and how

--- a/examples/audit-export-pattern.md
+++ b/examples/audit-export-pattern.md
@@ -1,0 +1,94 @@
+# Export and replay the audit log
+
+Goal: pull the NDJSON audit log for one session, walk the schema,
+correlate one entry back to the chat panel, and hand it to a
+downstream system (SIEM, ticketing, finance review).
+
+## 1. Pick a session
+
+```bash
+SESSION_ID=$(wget -qO - http://localhost:8080/api/sessions \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)[0]['id'])")
+echo "session: $SESSION_ID"
+```
+
+The first session in the list is fine for a walkthrough. In a real
+review you'd filter by date, project, or model.
+
+## 2. Pull the audit log
+
+The endpoint streams JSON by default and CSV when asked. Source:
+[`server/src/main.rs`](../server/src/main.rs) (see
+`api_export_audit`).
+
+```bash
+wget -qO audit.json \
+  "http://localhost:8080/api/proxy/audit/export?session_id=${SESSION_ID}&format=json&limit=10000"
+
+wget -qO audit.csv \
+  "http://localhost:8080/api/proxy/audit/export?session_id=${SESSION_ID}&format=csv&limit=10000"
+```
+
+For NDJSON-style streaming (one record per line, easier to feed into
+SIEM ingest):
+
+```bash
+python3 -c "import json; [print(json.dumps(e)) for e in json.load(open('audit.json'))]" > audit.ndjson
+```
+
+## 3. Walk one entry
+
+```bash
+python3 -c "
+import json
+entries = json.load(open('audit.json'))
+print(f'entries: {len(entries)}')
+print(json.dumps(entries[0], indent=2)[:800])
+"
+```
+
+Expected shape (abridged):
+
+```json
+{
+  "id": "01HX...",
+  "session_id": "<uuid>",
+  "ts_request": 1714200000.123,
+  "ts_response": 1714200001.456,
+  "method": "POST",
+  "url": "https://api.anthropic.com/v1/messages",
+  "model": "claude-3.5-sonnet",
+  "request_body_redacted": "...",
+  "response_body_redacted": "...",
+  "input_tokens": 1820,
+  "output_tokens": 510,
+  "status": 200,
+  "latency_ms": 1333
+}
+```
+
+`request_body_redacted` and `response_body_redacted` are post-redaction;
+`sk-…` keys, `Bearer …` tokens, and provider account ids are masked.
+
+## 4. Correlate the entry to the chat panel
+
+Take the `ts_request` of an entry, copy the timestamp, and scroll
+the chat panel for the same session to the matching turn. Each chat
+message exposes its source JSONL line — same evidence trail from
+two sides.
+
+## 5. Replay (read-only)
+
+The audit log holds the redacted request body. Replay against the
+proxy (with manual mode on, so you stay in the loop) is the safe
+default; replay against the upstream directly is only useful for
+offline benchmarking.
+
+## See also
+
+- [`codex-session-spawn.md`](codex-session-spawn.md) — generate a
+  session worth auditing in the first place
+- [`intercept-api-request.md`](intercept-api-request.md) — gate
+  requests at the moment they happen, not after the fact
+- [`docs/evidence-loop-details.md`](../docs/evidence-loop-details.md)
+  — full audit-log NDJSON schema and persistence layers

--- a/examples/codex-session-spawn.md
+++ b/examples/codex-session-spawn.md
@@ -1,0 +1,89 @@
+# Spawn a managed agent session
+
+Goal: launch any of Codex / Claude Code / Gemini CLI against the
+noaide proxy, see the session show up in the sidebar, watch the JSONL
+event stream render live.
+
+## 1. Allocate a session id
+
+```bash
+SESSION_ID=$(uuidgen)
+echo "session: $SESSION_ID"
+```
+
+The id is opaque; noaide uses it to namespace proxy traffic per
+session. Any UUID works.
+
+## 2. Point the agent at the proxy
+
+Pick the env-var line that matches your tool. The proxy listens on
+`localhost:4434` by default (`NOAIDE_PORT`).
+
+```bash
+# Codex (OpenAI):
+export OPENAI_BASE_URL="http://localhost:4434/s/${SESSION_ID}/backend-api/codex"
+
+# Claude Code (Anthropic):
+export ANTHROPIC_BASE_URL="http://localhost:4434/s/${SESSION_ID}"
+
+# Gemini CLI (Google):
+export CODE_ASSIST_ENDPOINT="http://localhost:4434/s/${SESSION_ID}"
+export GOOGLE_GEMINI_BASE_URL="http://localhost:4434/s/${SESSION_ID}"
+```
+
+The proxy detects the provider from the request path and forwards to
+the real endpoint. Source: [`server/src/proxy/handler.rs`](../server/src/proxy/handler.rs).
+
+## 3. Run the agent
+
+```bash
+codex                # or: claude  /  gemini
+> Add a unit test for the rate limiter and run it.
+```
+
+The agent runs as usual. noaide does not wrap it — the proxy sits in
+front of the API call only.
+
+## 4. Confirm the session is registered
+
+```bash
+wget -qO - http://localhost:8080/api/sessions \
+  | python3 -c "import json,sys; print('\n'.join(s['id'] for s in json.load(sys.stdin)))"
+```
+
+Expected: a line with the session UUID. If empty, the proxy did not
+see traffic — re-export the base URL and rerun.
+
+## 5. Watch the JSONL stream in the browser
+
+Open `https://localhost:9999/noaide/` (or whichever URL the
+deployment guide printed) in a Chromium-based browser. The new
+session appears in the left sidebar within ~1 s of the first
+agent reply.
+
+The chat panel renders every event in the transcript:
+
+```text
+Codex            : turn_context · agent_reasoning · agent_message · response_item · compacted
+Claude Code      : user · assistant · tool_use · tool_result · system-reminder
+Gemini CLI       : user · model · functionCall · functionResponse · systemInstruction
+```
+
+The events that the official CLI usually suppresses (system
+reminders, intermediate transcript fragments) render in line with
+the rest.
+
+## 6. Stop the session
+
+`Ctrl-C` the agent. The session card stays in the sidebar with a
+final state — the JSONL on disk is the source of truth, so the
+sidebar entry survives a noaide restart.
+
+## See also
+
+- [`intercept-api-request.md`](intercept-api-request.md) — modify a
+  request before it leaves the host
+- [`audit-export-pattern.md`](audit-export-pattern.md) — pull the
+  audit log NDJSON for the session you just spawned
+- [`docs/agent-operating-model.md`](../docs/agent-operating-model.md)
+  — managed vs observed sessions

--- a/examples/intercept-api-request.md
+++ b/examples/intercept-api-request.md
@@ -1,0 +1,88 @@
+# Intercept an API request before it leaves the host
+
+Goal: switch the proxy to manual mode, hold the next outbound
+request from any agent, edit it, and forward — or drop it.
+
+## 1. Make sure the agent is routed through the proxy
+
+Either of these env-var sets is enough (see
+[`codex-session-spawn.md`](codex-session-spawn.md) for the full
+list):
+
+```bash
+export OPENAI_BASE_URL="http://localhost:4434/s/${SESSION_ID}/backend-api/codex"
+# or
+export ANTHROPIC_BASE_URL="http://localhost:4434/s/${SESSION_ID}"
+# or
+export CODE_ASSIST_ENDPOINT="http://localhost:4434/s/${SESSION_ID}"
+export GOOGLE_GEMINI_BASE_URL="http://localhost:4434/s/${SESSION_ID}"
+```
+
+## 2. Switch the proxy to manual mode
+
+In the noaide UI, open the **Network** tab and click **Manual** in
+the mode bar. The mode now reads `manual` for every new request.
+
+Source: [`server/src/proxy/handler.rs`](../server/src/proxy/handler.rs)
+(see `intercept_mode`).
+
+## 3. Issue a request from the agent
+
+In the same shell where the agent runs:
+
+```text
+codex
+> List the open issues in this repo and pick the one with the most
+  +1 reactions.
+```
+
+The agent assembles a request and hits the proxy. The proxy holds
+the request and surfaces it in the **Network** tab inspector.
+
+## 4. Edit the held request
+
+The inspector shows headers and body in editable form. Common edits:
+
+- Change the model header (`x-model: claude-3.5-sonnet` →
+  `x-model: claude-3.5-haiku`) to compare cost.
+- Strip a tool from the `tools` array in the body to test the
+  agent's fallback behaviour.
+- Inject a `system` message at the top of `messages` to add
+  operator-side context.
+
+Click **Forward** to release the modified request. The agent sees
+the response normally and continues.
+
+## 5. Try the drop path
+
+Issue another prompt. When the request lands in the inspector,
+click **Drop** instead of **Forward**.
+
+Expected: the agent receives a 503 / connection-reset and reports
+the failure in plain text. It does not retry against the upstream;
+the proxy did not pass the request along.
+
+## 6. Confirm the redaction
+
+Click on a captured request in the list, open the body view, and
+search for `sk-`, `Bearer `, or your provider account id. Source:
+[`server/src/proxy/handler.rs`](../server/src/proxy/handler.rs)
+(see `redact_secrets`).
+
+Expected output:
+
+```text
+Authorization: Bearer ***
+x-api-key: sk-ant-***
+```
+
+The redaction runs before the request enters the audit log and
+before it appears in the UI. The actual upstream request is sent
+with the original credentials.
+
+## See also
+
+- [`audit-export-pattern.md`](audit-export-pattern.md) — pull the
+  NDJSON audit log of the session you just intercepted
+- [`docs/supervision-boundaries.md`](../docs/supervision-boundaries.md)
+  — the contract between operator and agent that this gate enforces


### PR DESCRIPTION
## Summary
New \`examples/\` directory with three copy-pasteable cookbook walkthroughs (≤ 100 lines each) plus an index README, providing the hands-on artefacts the workshop doc points to.

| File | Lines | Cross-tool? |
|---|---|---|
| \`examples/README.md\` | 23 | n/a |
| \`examples/codex-session-spawn.md\` | 89 | yes (OPENAI / ANTHROPIC / CODE_ASSIST_ENDPOINT) |
| \`examples/intercept-api-request.md\` | 88 | yes (OPENAI + ANTHROPIC + CODE_ASSIST_ENDPOINT shown side-by-side) |
| \`examples/audit-export-pattern.md\` | 94 | provider-agnostic |

Each file is self-contained, points back at the relevant source code (\`server/src/proxy/handler.rs\`, \`server/src/main.rs\`), and shows expected output for every command that produces one.

\`README.md\` documentation index now links \`examples/\` alongside the \`docs/\` deep-dives.

## Why
Audit v2 (CC-4 \`examples/\` directory pattern) flagged that noaide had no minimal reproducible Hands-on artefacts to back the workshop doc. Customer-engineering reviewers want copy-pasteable demos before they read deep-dives.

## Test plan
- [x] \`ls examples/\` → 4 files (README + 3 walkthroughs)
- [x] \`wc -l examples/*.md\` → all ≤ 100 lines (89 / 88 / 94 / 23)
- [x] Each walkthrough names cross-tool env vars where applicable (\`OPENAI_BASE_URL\`, \`ANTHROPIC_BASE_URL\`, \`CODE_ASSIST_ENDPOINT\`, \`GOOGLE_GEMINI_BASE_URL\`)
- [x] README documentation index links \`examples/\`
- [ ] CI green (Conventional Commits, CI Gate, CodeQL Gate, Language Gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)