### PR TITLE
docs(readme): add multi-session orchestration row to the status matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ will move as the project matures.
 | Audit export endpoint (NDJSON) | Partial |
 | Conflict resolution (OT buffer + 3-way merge UI) | Partial |
 | Cost dashboard (token tracking; real-dollar costs pending) | Partial |
+| Multi-session orchestration (topology + swimlane UI; live sub-agent wiring pending) | Partial ([#105](https://github.com/silentspike/noaide/issues/105)) |
 | Multi-account control plane | Roadmap ([#108](https://github.com/silentspike/noaide/issues/108)) |
 | Onboarding, keyboard help, ARIA, custom themes | Roadmap ([#107](https://github.com/silentspike/noaide/issues/107)) |
 


### PR DESCRIPTION
## Summary
The hero now describes "Multi-Session Orchestration" (PR #168) but the status matrix had no row for it. Add the row, classify it honestly:

\`\`\`
| Multi-session orchestration (topology + swimlane UI; live sub-agent wiring pending) | Partial ([#105](https://github.com/silentspike/noaide/issues/105)) |
\`\`\`

Bucket Partial because the UI components (TopologyGraph, SwimlaneTL, SubagentTree, TeamsPanel, AgentCard) are all on main, while live sub-agent wiring and Gantt-chart hookup are still open in [#105](https://github.com/silentspike/noaide/issues/105). Issue link lets a reader follow the gap directly.

Matrix grows from 10 to 11 capability rows.

## Test plan
- [x] \`grep "Multi-session orchestration" README.md\` → 1 hit
- [x] Bucket reads \`Partial ([#105](...))\` — issue link present
- [x] 11 capability rows total in the matrix
- [x] 4 bucket-definition rows still present
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)