### PR TITLE
docs(readme): remove redundant Transport badge from header

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Operator console for AI coding agents. Observe Codex / Claude Code / Gemini CLI 
 [![Status: Pre-Alpha](https://img.shields.io/badge/Status-Pre--Alpha-orange.svg)](#project-status)
 [![Rust](https://img.shields.io/badge/Rust-1.87+-dea584.svg)](https://www.rust-lang.org/)
 [![SolidJS](https://img.shields.io/badge/SolidJS-1.9+-4f88c6.svg)](https://www.solidjs.com/)
-[![Transport](https://img.shields.io/badge/Transport-HTTP%2F3%20QUIC-8b5cf6.svg)](#tech-stack)
 
 <br>
 


### PR DESCRIPTION
## Summary

Removes the `Transport: HTTP/3 QUIC` badge from the README header. The badge was self-promoting tech detail that duplicates information already documented in the Tech Stack table and `docs/performance.md`.

## Why

External portfolio review identified the Transport badge as 30s-skim noise — operator-relevant signals (CI, license, project status, language stack) are clearer without it. Performance/transport details remain in `docs/performance.md`.

## Test plan

- [x] README still renders correctly without the Transport badge
- [x] Tech Stack table still describes WebTransport (HTTP/3, QUIC) under Transport row
- [x] `docs/performance.md` Transport section unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)